### PR TITLE
Add Auth HealthCheck for Admin App

### DIFF
--- a/identity-admin-api/app/controllers/HealthCheckController.scala
+++ b/identity-admin-api/app/controllers/HealthCheckController.scala
@@ -1,15 +1,23 @@
 package controllers
 
+import javax.inject.Inject
+
+import actions.AuthenticatedAction
 import play.api.Logger
 import play.api.libs.json.Json
 import play.api.mvc.{Action, Results}
 
 case class Test(name: String, result: () => Boolean)
 
-class HealthCheckController extends Results {
+class HealthCheckController @Inject() (auth: AuthenticatedAction) extends Results {
 
   // TODO add a meaningful test
   val tests: Seq[Test] = Nil
+
+  def authHealthCheck() = auth {
+    Ok
+  }
+
 
   def healthCheck() = Action {
     Cached(1) {

--- a/identity-admin-api/conf/routes
+++ b/identity-admin-api/conf/routes
@@ -1,4 +1,5 @@
 GET        /healthcheck        @controllers.HealthCheckController.healthCheck
+GET        /authHealthcheck    @controllers.HealthCheckController.authHealthCheck
 
 GET        /v1/user/search     @controllers.UsersController.search(query: String, limit: Option[Int], offset: Option[Int])
 GET        /v1/user/:id        @controllers.UsersController.findById(id: String)


### PR DESCRIPTION
Create endpoint that can be used by another application to check if it can properly authenticate with the admin API