### PR TITLE
Fix stuff

### DIFF
--- a/identity-admin-api/app/models/User.scala
+++ b/identity-admin-api/app/models/User.scala
@@ -111,8 +111,6 @@ object User {
                   receiveGnmMarketing = user.statusFields.flatMap(_.receiveGnmMarketing),
                   userEmailValidated = user.statusFields.flatMap(_.userEmailValidated)
                 ),
-                groups = user.userGroups.map(g =>
-                  g.map(ug => UserGroup(ug.packageCode, ug.joinedDate)).toList
-                ).getOrElse(Nil)
+                groups = user.userGroups.map(g => UserGroup(g.packageCode, g.joinedDate))
     )
 }

--- a/identity-admin-api/app/repositories/PersistedUser.scala
+++ b/identity-admin-api/app/repositories/PersistedUser.scala
@@ -96,9 +96,9 @@ case class PersistedUser(primaryEmailAddress: String,
                 statusFields: Option[StatusFields] = None,
                 dates: Option[UserDates] = Some(new UserDates()),
                 password: Option[String] = None,
-                userGroups: Option[Set[GroupMembership]] = None,
-                socialLinks: Option[Set[SocialLink]] = None,
-                adData: Option[Map[String, Any]] = None
+                userGroups: List[GroupMembership] = Nil,
+                socialLinks: List[SocialLink] = Nil,
+                adData: Map[String, Any] = Map.empty
                  )
 
 object PersistedUser {

--- a/identity-admin-api/app/services/UserService.scala
+++ b/identity-admin-api/app/services/UserService.scala
@@ -22,10 +22,11 @@ class UserService @Inject() (usersReadRepository: UsersReadRepository,
 
     (emailValid, usernameValid) match {
       case (true, true) =>
-        val userEmailValidated = if(!user.email.equalsIgnoreCase(userUpdateRequest.email)) Some(false) else user.status.userEmailValidated
+        val userEmailChanged = !user.email.equalsIgnoreCase(userUpdateRequest.email)
+        val userEmailValidated = if(userEmailChanged) Some(false) else user.status.userEmailValidated
         val update = PersistedUserUpdate(userUpdateRequest, userEmailValidated)
         val result = usersWriteRepository.update(user, update)
-        if(result.isRight)
+        if(result.isRight && userEmailChanged)
           identityApiClient.sendEmailValidation(user.id)
         ApiResponse.Async(Future.successful(result))
       case (false, true) =>


### PR DESCRIPTION
Read/write issues:
- salat doesn't work with optional collections, so updates don't work when they are optional
- play's json format will treat missing paths in the json from reactive mongo as invalid, so needs optional collections. 
- use explicit json formatting so that reactive mongo can treat the collections as optional on read, but salat will continue to work as they are not optional in the object
- the sooner we upgrade mongo and can use reactive mongo for reads, the better.

Also..
- only send validation email when it has changed