### PR TITLE
Manually encoding white space.

### DIFF
--- a/identity-admin-api/app/actions/AuthenticatedAction.scala
+++ b/identity-admin-api/app/actions/AuthenticatedAction.scala
@@ -34,7 +34,7 @@ trait AuthenticatedAction extends ActionBuilder[Request] with Logging {
       val authorization = request.headers.get(HeaderNames.AUTHORIZATION).getOrElse(throw new IllegalArgumentException("Authorization header is required."))
       val hmac = extractToken(authorization).getOrElse(throw new IllegalArgumentException("Authorization header is invalid."))
       val date = request.headers.get(HeaderNames.DATE).getOrElse(throw new scala.IllegalArgumentException("Date header is required."))
-      val uri = getPath(request)
+      val uri = request.uri
 
       logger.info(s"path: $uri, date: $date, hmac: $hmac")
 
@@ -49,11 +49,6 @@ trait AuthenticatedAction extends ActionBuilder[Request] with Logging {
       case Success(r) => block(request)
       case Failure(t) => Future.successful(ApiErrors.unauthorized(t.getMessage))
     }
-  }
-
-  private[actions] def getPath(request: Request[Any]): String = {
-    val queryString = request.rawQueryString
-    if(queryString == null || queryString.isEmpty) request.path else s"${request.path}?$queryString"
   }
 
   private[actions] def extractToken(authHeader: String): Option[String] = {

--- a/identity-admin-api/app/controllers/UsersController.scala
+++ b/identity-admin-api/app/controllers/UsersController.scala
@@ -31,7 +31,8 @@ class UsersController @Inject() (userService: UserService, auth: AuthenticatedAc
       }
       else {
         val formattedQuery = query.replace(" ", "%20")
-        userService.search(UriEncoding.decodePathSegment(formattedQuery, "UTF-8"), limit, offset)
+        val encodedQuery = UriEncoding.decodePathSegment(formattedQuery, "UTF-8")
+        userService.search(encodedQuery, limit, offset)
       }
     }
   }

--- a/identity-admin-api/app/controllers/UsersController.scala
+++ b/identity-admin-api/app/controllers/UsersController.scala
@@ -30,7 +30,8 @@ class UsersController @Inject() (userService: UserService, auth: AuthenticatedAc
         ApiResponse.Left(ApiErrors.badRequest(s"query must be a minimum of $MinimumQueryLength characters"))
       }
       else {
-        userService.search(query, limit, offset)
+        val formattedQuery = query.replace(" ", "%20")
+        userService.search(UriEncoding.decodePathSegment(formattedQuery, "UTF-8"), limit, offset)
       }
     }
   }


### PR DESCRIPTION
White space needs to be encoded as %20 so that the string it is part of can be decoded correctly.