### PR TITLE
Install and run unattended-upgrades at boot

### DIFF
--- a/cloudformation/identity-admin-api.json
+++ b/cloudformation/identity-admin-api.json
@@ -299,6 +299,10 @@
                 "Ref": "Stage"
               }, "'\n",
 
+              "apt-get update\n",
+              "apt-get install -y unattended-upgrades\n",
+              "unattended-upgrade --debug\n",
+
               "aws s3 cp s3://gu-identity-dist/cwlogs-setup.sh .\n",
               "chmod +x cwlogs-setup.sh\n",
               "./cwlogs-setup.sh\n",

--- a/cloudformation/identity-admin-api.json
+++ b/cloudformation/identity-admin-api.json
@@ -299,13 +299,13 @@
                 "Ref": "Stage"
               }, "'\n",
 
-              "apt-get update\n",
-              "apt-get install -y unattended-upgrades\n",
-              "unattended-upgrade --debug\n",
-
               "aws s3 cp s3://gu-identity-dist/cwlogs-setup.sh .\n",
               "chmod +x cwlogs-setup.sh\n",
               "./cwlogs-setup.sh\n",
+
+              "aws s3 cp s3://gu-identity-dist/security-updates.sh .\n",
+              "chmod +x security-updates.sh\n",
+              "./security-updates.sh\n",
 
               "aws s3 cp s3://gu-identity-dist/cron-setup.sh .\n",
               "chmod +x cron-setup.sh\n",


### PR DESCRIPTION
Uses the Debian/Ubuntu `unattended-upgrades` package (https://help.ubuntu.com/community/AutomaticSecurityUpdates#Using_the_.22unattended-upgrades.22_package)