### PR TITLE
Return more informative error messages if the user account cannot be …

### DIFF
--- a/identity-admin-api/app/repositories/UsersWriteRepository.scala
+++ b/identity-admin-api/app/repositories/UsersWriteRepository.scala
@@ -85,11 +85,17 @@ class UsersWriteRepository extends SalatDAO[PersistedUser, String](collection=Sa
         Right(User.fromPersistedUser(userToSave))
       case Failure(t) =>
         logger.error(s"Failed to update user. id: ${userToSave._id}", t)
-        if (t.toString contains "primaryEmailAddress")
-          Left(ApiErrors.internalError("email address is already in use."))
-        else
-          Left(ApiErrors.internalError("username is already in use"))
+        val errorMessage = generateErrorMessage(t)
+        Left(ApiErrors.internalError(errorMessage))
     }
+  }
+
+  private def generateErrorMessage(error: Throwable): String = {
+    val errorText = error.toString
+    if (errorText contains "E11000 duplicate key error")
+      "this data is already in use in the database"
+    else
+      "update could not be performed contact identitydev@guardian.co.uk"
   }
 
   def delete(user: User): Either[ApiError, Boolean] = {

--- a/identity-admin-api/app/repositories/UsersWriteRepository.scala
+++ b/identity-admin-api/app/repositories/UsersWriteRepository.scala
@@ -85,7 +85,10 @@ class UsersWriteRepository extends SalatDAO[PersistedUser, String](collection=Sa
         Right(User.fromPersistedUser(userToSave))
       case Failure(t) =>
         logger.error(s"Failed to update user. id: ${userToSave._id}", t)
-        Left(ApiErrors.internalError(t.getMessage))
+        if (t.toString contains "primaryEmailAddress")
+          Left(ApiErrors.internalError("email address is already in use."))
+        else
+          Left(ApiErrors.internalError("username is already in use"))
     }
   }
 


### PR DESCRIPTION
…updated because the username or email is already in use.

Fixes the problem of stack trace being returned in the error message when a username or email is already in use

