### PR TITLE
Change log format to get stack trace into Kibana

### DIFF
--- a/identity-admin-api/conf/application-logger.xml
+++ b/identity-admin-api/conf/application-logger.xml
@@ -15,7 +15,7 @@
             <maxFileSize>5MB</maxFileSize>
         </triggeringPolicy>
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36}:%line - %msg%n%xException{full}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36}:%line - %msg %xException{full}%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Changed to match the format in identity-api. Looks like the `%n` was preventing it from showing up in Kibana properly.