### PR TITLE
Expire HMAC after 5 mins and require HTTP date format from RFC 7231

### DIFF
--- a/identity-admin-api/app/actions/AuthenticatedAction.scala
+++ b/identity-admin-api/app/actions/AuthenticatedAction.scala
@@ -60,7 +60,7 @@ trait AuthenticatedAction extends ActionBuilder[Request] with Logging {
     } match {
       case Success(r) => r
       case Failure(t) =>
-        logger.info(s"Date header could not be parsed: ${t.getMessage}")
+        logger.error(s"Date header could not be parsed", t)
         false
     }
   }

--- a/identity-admin-api/app/actions/AuthenticatedAction.scala
+++ b/identity-admin-api/app/actions/AuthenticatedAction.scala
@@ -8,9 +8,10 @@ import com.gu.identity.util.Logging
 import configuration.Config
 import models.ApiErrors
 import org.apache.commons.codec.binary.Base64
+import org.joda.time.{DateTimeZone, DateTime}
 import play.api.http.HeaderNames
-import play.api.libs.ws.WSRequest
 import play.api.mvc.{Request, Result, _}
+import util.Formats
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
@@ -26,8 +27,9 @@ trait AuthenticatedAction extends ActionBuilder[Request] with Logging {
 
   def secret: String
 
-  private val ALGORITHM = "HmacSHA256"
-  private val HMAC_PATTERN = "HMAC\\s(.+)".r
+  private val Algorithm = "HmacSHA256"
+  private val HmacPattern = "HMAC\\s(.+)".r
+  private[actions] val HmacValidDurationInMinutes = 5
 
   def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
     Try {
@@ -38,9 +40,7 @@ trait AuthenticatedAction extends ActionBuilder[Request] with Logging {
 
       logger.info(s"path: $uri, date: $date, hmac: $hmac")
 
-      val signed = sign(date, uri)
-
-      if (signed == hmac) {
+      if (isDateValid(date) && isHmacValid(date, uri, hmac)) {
         Success
       } else {
         throw new IllegalArgumentException("Authorization token is invalid.")
@@ -51,8 +51,25 @@ trait AuthenticatedAction extends ActionBuilder[Request] with Logging {
     }
   }
 
+  private def isDateValid(date: String): Boolean  = {
+    Try {
+      val d = Formats.toDateTime(date)
+      val now = DateTime.now(DateTimeZone.forID("GMT"))
+      val expires = d.plusMinutes(HmacValidDurationInMinutes)
+      if (now.isAfter(expires)) false else true
+    } match {
+      case Success(r) => r
+      case Failure(t) =>
+        logger.info(s"Date header could not be parsed: ${t.getMessage}")
+        false
+    }
+  }
+
+  private def isHmacValid(date: String, uri: String, hmac: String): Boolean =
+    sign(date, uri) == hmac
+
   private[actions] def extractToken(authHeader: String): Option[String] = {
-    val matched = HMAC_PATTERN.findAllIn(authHeader).matchData map {
+    val matched = HmacPattern.findAllIn(authHeader).matchData map {
       m => m.group(1)
     }
 
@@ -67,8 +84,8 @@ trait AuthenticatedAction extends ActionBuilder[Request] with Logging {
 
 
   private def calculateHMAC(toEncode: String): String = {
-    val signingKey = new SecretKeySpec(secret.getBytes, ALGORITHM)
-    val mac = Mac.getInstance(ALGORITHM)
+    val signingKey = new SecretKeySpec(secret.getBytes, Algorithm)
+    val mac = Mac.getInstance(Algorithm)
     mac.init(signingKey)
     val rawHmac = mac.doFinal(toEncode.getBytes)
     new String(Base64.encodeBase64(rawHmac))

--- a/identity-admin-api/app/controllers/Cached.scala
+++ b/identity-admin-api/app/controllers/Cached.scala
@@ -3,6 +3,7 @@ package controllers
 import com.github.nscala_time.time.Imports._
 import org.joda.time.DateTime
 import play.api.mvc.Result
+import util.Formats
 
 import scala.math.max
 
@@ -25,14 +26,10 @@ object Cached {
     val staleWhileRevalidateSeconds = max(maxAge / 10, 1)
     result.withHeaders(
       "Cache-Control" -> s"public, max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$tenDaysInSeconds",
-      "Expires" -> toHttpDateTimeString(now + maxAge.seconds),
-      "Date" -> toHttpDateTimeString(now)
+      "Expires" -> Formats.toHttpDateTimeString(now + maxAge.seconds),
+      "Date" -> Formats.toHttpDateTimeString(now)
     )
   }
-
-  //http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1
-  private val HTTPDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(DateTimeZone.UTC)
-  def toHttpDateTimeString(dateTime: DateTime): String = dateTime.toString(HTTPDateFormat)
 }
 
 object NoCache {

--- a/identity-admin-api/app/util/Formats.scala
+++ b/identity-admin-api/app/util/Formats.scala
@@ -1,0 +1,13 @@
+package util
+
+import com.github.nscala_time.time.Imports._
+import org.joda.time.DateTime
+
+object Formats {
+
+  // http://tools.ietf.org/html/rfc7231#section-7.1.1.2
+  private val HTTPDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(DateTimeZone.forID("GMT"))
+
+  def toHttpDateTimeString(dateTime: DateTime): String = dateTime.withZone(DateTimeZone.forID("GMT")).toString(Formats.HTTPDateFormat)
+  def toDateTime(date: String): DateTime = HTTPDateFormat.parseDateTime(date)
+}

--- a/identity-admin-api/test/actions/AuthenticatedActionTest.scala
+++ b/identity-admin-api/test/actions/AuthenticatedActionTest.scala
@@ -1,11 +1,13 @@
 package actions
 
 import models.ApiErrors
+import org.joda.time.{DateTimeZone, DateTime}
 import org.mockito.Mockito
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 import play.api.http.HeaderNames
 import play.api.mvc.{Results, Request, Result}
 import play.api.test.FakeRequest
+import util.Formats
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
@@ -43,6 +45,8 @@ class AuthenticatedActionTest extends WordSpec with Matchers with BeforeAndAfter
 
     def block(request: Request[Any]): Future[Result] = Future.successful(Results.Ok)
 
+    val dateHeaderValue = Formats.toHttpDateTimeString(DateTime.now)
+
     def verifyUnauthorized(result: Future[Result], errorMessage: String) = {
       status(result) shouldEqual UNAUTHORIZED
       contentAsJson(result) shouldEqual Json.toJson(ApiErrors.unauthorized(errorMessage))
@@ -55,7 +59,7 @@ class AuthenticatedActionTest extends WordSpec with Matchers with BeforeAndAfter
     }
 
     "Return unauthorised if Authorization header is missing" in {
-      val request = FakeRequest().withHeaders(HeaderNames.DATE -> "2015-10-23T11:53:00Z")
+      val request = FakeRequest().withHeaders(HeaderNames.DATE -> dateHeaderValue)
       val result = action.invokeBlock(request, block)
       verifyUnauthorized(result, "Authorization header is required.")
     }
@@ -63,14 +67,13 @@ class AuthenticatedActionTest extends WordSpec with Matchers with BeforeAndAfter
     "Return unauthorised if HMAC token cannot be extracted from Authorization header" in {
       val authHeaderValue = "auth"
       doReturn(None).when(action).extractToken(authHeaderValue)
-      val request = FakeRequest().withHeaders(HeaderNames.DATE -> "2015-10-23T11:53:00Z", HeaderNames.AUTHORIZATION -> authHeaderValue)
+      val request = FakeRequest().withHeaders(HeaderNames.DATE -> dateHeaderValue, HeaderNames.AUTHORIZATION -> authHeaderValue)
       val result = action.invokeBlock(request, block)
       verifyUnauthorized(result, "Authorization header is invalid.")
     }
 
     "Return unauthorised if HMAC token does not match calculated HMAC" in {
       val authHeaderValue = "HMAC 12345"
-      val dateHeaderValue = "2015-10-23T11:53:00Z"
       val path= "/v1/user/id?param=val"
       doReturn(Some(authHeaderValue)).when(action).extractToken(authHeaderValue)
       doReturn("differentHmac").when(action).sign(dateHeaderValue, path)
@@ -79,8 +82,25 @@ class AuthenticatedActionTest extends WordSpec with Matchers with BeforeAndAfter
       verifyUnauthorized(result, "Authorization token is invalid.")
     }
 
+    "Return unauthorised if HMAC has expired" in {
+      val path= "/v1/user/id?param=val"
+      val dateHeader = Formats.toHttpDateTimeString(DateTime.now.plusMinutes(action.HmacValidDurationInMinutes + 1))
+      val authHeaderValue = s"HMAC ${action.sign(dateHeaderValue, path)}"
+      val request = FakeRequest("GET", path).withHeaders(HeaderNames.DATE -> dateHeader, HeaderNames.AUTHORIZATION -> authHeaderValue)
+      val result = action.invokeBlock(request, block)
+      verifyUnauthorized(result, "Authorization token is invalid.")
+    }
+
+    "Return unauthorised if Date cannot be parsed" in {
+      val path= "/v1/user/id?param=val"
+      val dateHeader = DateTime.now.withZone(DateTimeZone.forID("GMT")).toString("yyyy-MM-dd'T'HH:mm:ss")
+      val authHeaderValue = s"HMAC ${action.sign(dateHeaderValue, path)}"
+      val request = FakeRequest("GET", path).withHeaders(HeaderNames.DATE -> dateHeader, HeaderNames.AUTHORIZATION -> authHeaderValue)
+      val result = action.invokeBlock(request, block)
+      verifyUnauthorized(result, "Authorization token is invalid.")
+    }
+
     "Execute block if auhorization header value matches calculated signed request" in {
-      val dateHeaderValue = "2015-10-23T11:53:00Z"
       val path= "/v1/user/id?param=val"
       val authHeaderValue = s"HMAC ${action.sign(dateHeaderValue, path)}"
       val request = FakeRequest("GET", path).withHeaders(HeaderNames.DATE -> dateHeaderValue, HeaderNames.AUTHORIZATION -> authHeaderValue)


### PR DESCRIPTION
- Date header values should be in the format defined by RFC 7231 http://tools.ietf.org/html/rfc7231#section-7.1.1.2
- As we sign HMACs using the current date time, we should expire after a defined period. For now I have set this to be 5 mins.