### PR TITLE
Email validated fix

### DIFF
--- a/identity-admin-api/conf/DEV.conf
+++ b/identity-admin-api/conf/DEV.conf
@@ -20,5 +20,5 @@ monitoring {
 events {
   enabled = true
   email-validation-changed-sns-topic-arn = "arn:aws:sns:eu-west-1:942464564246:DEV-TopicEmailValidationChanged"
-  displayname-changed-sns-topic-arn = "arn:aws:sns:eu-west-1:942464564246:DEV-TopicEmailValidationChanged"
+  displayname-changed-sns-topic-arn = "arn:aws:sns:eu-west-1:942464564246:DEV-TopicDisplayNameChanged"
 }


### PR DESCRIPTION
- replaces equals syntax for more readability
- updated display name config on DEV
- `userEmailValidatedChanged` was not being used, I suppose it was a mistake?