### PR TITLE
Improve HMAC code

### DIFF
--- a/identity-admin-api/test/actions/AuthenticatedActionTest.scala
+++ b/identity-admin-api/test/actions/AuthenticatedActionTest.scala
@@ -97,7 +97,7 @@ class AuthenticatedActionTest extends WordSpec with Matchers with BeforeAndAfter
       val authHeaderValue = s"HMAC ${action.sign(dateHeaderValue, path)}"
       val request = FakeRequest("GET", path).withHeaders(HeaderNames.DATE -> dateHeader, HeaderNames.AUTHORIZATION -> authHeaderValue)
       val result = action.invokeBlock(request, block)
-      verifyUnauthorized(result, "Authorization token is invalid.")
+      verifyUnauthorized(result, "Date header is of invalid format.")
     }
 
     "Execute block if auhorization header value matches calculated signed request" in {


### PR DESCRIPTION
- The regexp matching that extracts the HMAC string returns a mutable
iterator, which can cause hard to debug side-effects.
This change turns it into an option in one single line.

- Throw a distinc exception when the date header parsing fails, to aid
  with developing new clients