### PR TITLE
Remove encoding MongoDB query as URI

### DIFF
--- a/identity-admin-api/app/controllers/UsersController.scala
+++ b/identity-admin-api/app/controllers/UsersController.scala
@@ -7,7 +7,6 @@ import models._
 import play.api.libs.json.{JsError, JsSuccess}
 import play.api.mvc._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import play.utils.UriEncoding
 import services.UserService
 
 import scala.concurrent.Future
@@ -30,9 +29,7 @@ class UsersController @Inject() (userService: UserService, auth: AuthenticatedAc
         ApiResponse.Left(ApiErrors.badRequest(s"query must be a minimum of $MinimumQueryLength characters"))
       }
       else {
-        val formattedQuery = query.replace(" ", "%20")
-        val encodedQuery = UriEncoding.decodePathSegment(formattedQuery, "UTF-8")
-        userService.search(encodedQuery, limit, offset)
+        userService.search(query, limit, offset)
       }
     }
   }


### PR DESCRIPTION
@nlindblad 

`query` parameter represents a [MongoDB query](https://docs.mongodb.com/manual/tutorial/query-documents/) and has nothing to do with URI. Hence it is not necessary to use `UriEncoding`