### PR TITLE
Send event to SNS when e-mail validation is updated manually

### DIFF
--- a/cloudformation/identity-admin-api.json
+++ b/cloudformation/identity-admin-api.json
@@ -126,6 +126,16 @@
       "PROD": {
         "ssl": "arn:aws:iam::942464564246:server-certificate/star.gutools.co.uk-exp2018-11-17"
       }
+    },
+    "SNSMap": {
+      "CODE": {
+        "emailValidationChangedTopic": "arn:aws:sns:eu-west-1:942464564246:CODE-TopicEmailValidationChanged",
+        "displayNameChangedTopic": "arn:aws:sns:eu-west-1:942464564246:CODE-TopicDisplayNameChanged"
+      },
+      "PROD": {
+        "emailValidationChangedTopic": "arn:aws:sns:eu-west-1:942464564246:PROD-TopicEmailValidationChanged",
+        "displayNameChangedTopic": "arn:aws:sns:eu-west-1:942464564246:PROD-TopicDisplayNameChanged"
+      }
     }
   },
 
@@ -165,6 +175,16 @@
                   "logs:*"
                 ],
                 "Resource": "*"
+              },
+              {
+                "Effect":"Allow",
+                "Action":["sns:Publish"],
+                "Resource": { "Fn::FindInMap": [ "SNSMap", { "Ref": "Stage" } , "emailValidationChangedTopic" ]}
+              },
+              {
+                "Effect":"Allow",
+                "Action":["sns:Publish"],
+                "Resource": { "Fn::FindInMap": [ "SNSMap", { "Ref": "Stage" } , "displayNameChangedTopic" ]}
               }
             ]
           }

--- a/identity-admin-api/app/actors/EventPublishingActor.scala
+++ b/identity-admin-api/app/actors/EventPublishingActor.scala
@@ -35,7 +35,7 @@ class EventPublishingActor(amazonSNSAsyncClient: AmazonSNSAsyncClient) extends A
 
   override def receive: Receive = {
     case emailValidationChanged: EmailValidationChanged => {
-      logger.debug(s"Sending email validation changed event to SNS for user ${emailValidationChanged.userId}")
+      logger.info(s"Sending email validation changed event to SNS for user ${emailValidationChanged.userId}")
       val subject = "E-mail Validation Changed"
       val message: String = write(emailValidationChanged)
       Try(amazonSNSAsyncClient.publishAsync(new PublishRequest(emailValidationChangedTopicArn, message, subject))) match {

--- a/identity-admin-api/app/services/SimpleNotificationService.scala
+++ b/identity-admin-api/app/services/SimpleNotificationService.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.amazonaws.regions.{ServiceAbbreviations, Region}
+import com.amazonaws.regions.{Region, ServiceAbbreviations}
 import com.amazonaws.services.sns.AmazonSNSAsyncClient
 import configuration.Config
 

--- a/identity-admin-api/app/services/UserService.scala
+++ b/identity-admin-api/app/services/UserService.scala
@@ -110,7 +110,10 @@ class UserService @Inject() (usersReadRepository: UsersReadRepository,
 
   private def doValidateEmail(user: User, emailValidated: Boolean): Either[ApiError, Boolean] = {
     usersWriteRepository.updateEmailValidationStatus(user, emailValidated) match{
-      case Right(r) => Right(true)
+      case Right(r) => {
+        triggerEvents(user.id, usernameChanged = false, emailValidatedChanged = true)
+        Right(true)
+      }
       case Left(r) => Left(r)
     }
   }


### PR DESCRIPTION
Turns out that:

1. the e-mail validation change was written to MongoDB but did not trigger the event that in turn publishes to SNS 
2. the EC2 instances didn’t have permissions to publish to the SNS topics and the async client just failed silently.