### PR TITLE
Add SG parameter for Vulnerability Scanning

### DIFF
--- a/cloudformation/identity-admin-api.json
+++ b/cloudformation/identity-admin-api.json
@@ -72,6 +72,10 @@
       "Description": "Security group that is allowed SSH access to the instances",
       "Type": "AWS::EC2::SecurityGroup::Id"
     },
+    "VulnerabilityScanningSecurityGroup": {
+      "Description": "Security group that grants access to the account's Vulnerability Scanner",
+      "Type": "AWS::EC2::SecurityGroup::Id"
+    },
     "PrivateVpcSubnets" : {
       "Description": "Private subnets to use in VPC",
       "Type": "List<AWS::EC2::Subnet::Id>"
@@ -333,6 +337,7 @@
         "ImageId": {"Ref": "AmiId"},
         "SecurityGroups": [
           {"Ref": "InstanceSecurityGroup"},
+          {"Ref": "VulnerabilityScanningSecurityGroup"},
           {"Ref": "SshAccessSecurityGroup"}
         ],
         "InstanceType": {"Ref": "InstanceType"},


### PR DESCRIPTION
There is now a vulnerability scanner in the Identity account. This PR lets us add a Security Group to instances to allow vulnerability scans.
