### PR TITLE
Give DAPI time to update on deletion

### DIFF
--- a/identity-admin-api/app/actors/EventPublishingActor.scala
+++ b/identity-admin-api/app/actors/EventPublishingActor.scala
@@ -44,7 +44,7 @@ class EventPublishingActor(amazonSNSAsyncClient: AmazonSNSAsyncClient) extends A
       }
     }
     case displayNameChanged: DisplayNameChanged => {
-      logger.debug(s"Sending displayname changed event to SNS for user ${displayNameChanged.userId}")
+      logger.info(s"Sending displayname changed event to SNS for user ${displayNameChanged.userId}")
       val subject = "Display Name Changed"
       val message: String = write(displayNameChanged)
       Try(amazonSNSAsyncClient.publishAsync(new PublishRequest(displayNameChangedTopicArn, message, subject))) match {

--- a/identity-admin-api/app/controllers/UsersController.scala
+++ b/identity-admin-api/app/controllers/UsersController.scala
@@ -85,8 +85,8 @@ class UsersController @Inject() (
     val originalUsername = request.user.username
     val anonymisedUsername = new Random(System.currentTimeMillis).alphanumeric.take(16).mkString
 
-    val anonymiseUsername = EitherT.fromEither(userService.update(request.user, UserUpdateRequest(request.user.email, Some(anonymisedUsername), Some(anonymisedUsername))).asFuture)
-    val deleteAccount =  EitherT.fromEither(userService.delete(request.user.id, originalUsername).asFuture)
+    def anonymiseUsername() = EitherT.fromEither(userService.update(request.user, UserUpdateRequest(request.user.email, Some(anonymisedUsername), Some(anonymisedUsername))).asFuture)
+    def deleteAccount() = EitherT.fromEither(userService.delete(request.user.id, originalUsername).asFuture)
 
     (for {
       _ <- anonymiseUsername

--- a/identity-admin-api/app/filters/AddEC2InstanceHeader.scala
+++ b/identity-admin-api/app/filters/AddEC2InstanceHeader.scala
@@ -1,5 +1,6 @@
 package filters
 
+import configuration.Config
 import play.api.Play.current
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.ws.WS
@@ -10,7 +11,10 @@ import scala.concurrent.Future
 object AddEC2InstanceHeader extends Filter {
 
   // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-  lazy val instanceIdOptF = WS.url("http://169.254.169.254/latest/meta-data/instance-id").get().map(resp => Some(resp.body).filter(_.nonEmpty)).recover { case _ => None }
+  lazy val instanceIdOptF = if (Config.stage == "PROD")
+    WS.url("http://169.254.169.254/latest/meta-data/instance-id").get().map(resp => Some(resp.body).filter(_.nonEmpty)).recover { case _ => None }
+  else
+    Future(None)
 
   def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = for {
     result <- nextFilter(requestHeader)

--- a/identity-admin-api/app/services/UserService.scala
+++ b/identity-admin-api/app/services/UserService.scala
@@ -109,6 +109,10 @@ class UserService @Inject() (usersReadRepository: UsersReadRepository,
   }
 
   def delete(userId: String, usernameToReserve: Option[String]): ApiResponse[ReservedUsernameList] = {
+    /* FIXME: give discussion chance to update anonymised username before deletion
+       https://github.com/guardian/discussion-platform/blob/9bd52222c988af50bfbf42fa3a8369048c509114/identitysync/lambda/IdentitySync.js */
+    Thread.sleep(10000)
+
     val result = usersWriteRepository.delete(userId) match{
       case Right(r) =>
         usernameToReserve.map(username => reservedUserNameRepository.addReservedUsername(username)).getOrElse {


### PR DESCRIPTION
When username is changed a notification is sent to DAPI SNS and then a lambda updates DAPI database by first querying ID and then actually performing the update:
https://github.com/guardian/discussion-platform/blob/9bd52222c988af50bfbf42fa3a8369048c509114/identitysync/lambda/IdentitySync.js

So when we anonymise the username we need to give DAPI some time to query ID before we actually delete the account.