### PR TITLE
Fix thread resource leak

### DIFF
--- a/identity-admin-api/app/controllers/HealthCheckController.scala
+++ b/identity-admin-api/app/controllers/HealthCheckController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
 import actions.AuthenticatedAction
 import play.api.Logger
@@ -9,6 +9,7 @@ import play.api.mvc.{Action, Results}
 
 case class Test(name: String, result: () => Boolean)
 
+@Singleton
 class HealthCheckController @Inject() (auth: AuthenticatedAction) extends Results {
 
   // TODO add a meaningful test

--- a/identity-admin-api/app/controllers/ReservedUsernameController.scala
+++ b/identity-admin-api/app/controllers/ReservedUsernameController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
 import actions.AuthenticatedAction
 import com.gu.identity.util.Logging
@@ -15,6 +15,7 @@ object ReservedUsernameRequest {
   implicit val format = Json.format[ReservedUsernameRequest]
 }
 
+@Singleton
 class ReservedUsernameController @Inject() (reservedUsernameRepository: ReservedUserNameWriteRepository, auth: AuthenticatedAction) extends Controller with Logging {
 
   def reserveUsername() = auth(parse.json) { request =>

--- a/identity-admin-api/app/controllers/UsersController.scala
+++ b/identity-admin-api/app/controllers/UsersController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
 import actions.AuthenticatedAction
 import com.gu.identity.util.Logging
@@ -17,6 +17,7 @@ import scalaz.std.scalaFuture._
 
 class UserRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)
 
+@Singleton
 class UsersController @Inject() (
     userService: UserService,
     auth: AuthenticatedAction,

--- a/identity-admin-api/app/repositories/ReactiveMongoConnection.scala
+++ b/identity-admin-api/app/repositories/ReactiveMongoConnection.scala
@@ -1,6 +1,6 @@
 package repositories
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
 import com.gu.identity.util.Logging
 import configuration.MongoConfig
@@ -9,6 +9,7 @@ import reactivemongo.api.{DefaultDB, MongoConnection, MongoDriver}
 
 import scala.concurrent.Future
 
+@Singleton
 class ReactiveMongoConnection @Inject() (mongoConfig: MongoConfig, app: play.api.Application) extends Logging {
 
   private var mongoDb: Option[DefaultDB] = None

--- a/identity-admin-api/app/repositories/UsersReadRepository.scala
+++ b/identity-admin-api/app/repositories/UsersReadRepository.scala
@@ -6,6 +6,7 @@ import com.gu.identity.util.Logging
 import models.{SearchResponse, User}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
+import play.modules.reactivemongo.ReactiveMongoApi
 import play.modules.reactivemongo.json._
 import play.modules.reactivemongo.json.collection._
 import reactivemongo.api.{QueryOpts, ReadPreference}
@@ -14,11 +15,11 @@ import scala.concurrent.Future
 
 
 @Singleton
-class UsersReadRepository @Inject() (reactiveMongoConnection: ReactiveMongoConnection) extends Logging {
+class UsersReadRepository @Inject() (app: play.api.Application) extends Logging {
 
   private val MaximumResults = 20
 
-  private def jsonCollection = reactiveMongoConnection.db().collection[JSONCollection]("users")
+  lazy val jsonCollection = app.injector.instanceOf[ReactiveMongoApi].db.collection[JSONCollection]("users")
 
   def search(query: String, limit: Option[Int] = None, offset: Option[Int] = None): Future[SearchResponse] =  {
     val q = buildSearchQuery(query)

--- a/identity-admin-api/app/repositories/UsersReadRepository.scala
+++ b/identity-admin-api/app/repositories/UsersReadRepository.scala
@@ -1,7 +1,8 @@
 package repositories
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
+import com.gu.identity.util.Logging
 import models.{SearchResponse, User}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
@@ -12,7 +13,8 @@ import reactivemongo.api.{QueryOpts, ReadPreference}
 import scala.concurrent.Future
 
 
-class UsersReadRepository @Inject() (reactiveMongoConnection: ReactiveMongoConnection) {
+@Singleton
+class UsersReadRepository @Inject() (reactiveMongoConnection: ReactiveMongoConnection) extends Logging {
 
   private val MaximumResults = 20
 

--- a/identity-admin-api/app/services/UserService.scala
+++ b/identity-admin-api/app/services/UserService.scala
@@ -1,6 +1,6 @@
 package services
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
 import actors.EventPublishingActor.{DisplayNameChanged, EmailValidationChanged}
 import actors.EventPublishingActorProvider
@@ -13,6 +13,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import configuration.Config.PublishEvents.eventsEnabled
 
+@Singleton
 class UserService @Inject() (usersReadRepository: UsersReadRepository,
                              usersWriteRepository: UsersWriteRepository,
                              reservedUserNameRepository: ReservedUserNameWriteRepository,


### PR DESCRIPTION
Play 2.5 by default creates a new instance of controllers on each
request unless you label them @Singleton:

https://www.playframework.com/documentation/2.5.x/ScalaDependencyInjection#component-lifecycle