### PR TITLE
Revert anonymisation on deletion

### DIFF
--- a/app/controllers/UsersController.scala
+++ b/app/controllers/UsersController.scala
@@ -13,9 +13,6 @@ import play.api.mvc._
 import services._
 
 import scala.concurrent.Future
-import scala.util.Random
-import scalaz.EitherT
-import scalaz.std.scalaFuture._
 
 class UserRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)
 
@@ -93,29 +90,14 @@ class UsersController @Inject() (
   }
 
   def delete(id: String) = (auth andThen UserAction(id)).async { request =>
-    logger.info(s"Deleting user $id")
+    logger.info(s"Deleting user with id: $id")
+    userService.delete(request.user).asFuture.map {
+      case Right(r) =>
+        EmailService.sendDeletionConfirmation(request.user.email)
+        NoContent
 
-    val originalUsername = request.user.username
-    val anonymisedUsername = new Random(System.currentTimeMillis).alphanumeric.take(16).mkString
-
-    def anonymiseUsername() = EitherT.fromEither(userService.update(request.user, UserUpdateRequest(request.user.email, Some(anonymisedUsername), Some(anonymisedUsername))).asFuture)
-    def unsubscribeEmails() = EitherT(ExactTargetService.unsubscribeFromAllLists(request.user.email)).leftMap(error => ApiErrors.internalError(error.toString))
-    def deleteAccount() = EitherT.fromEither(userService.delete(request.user.id, originalUsername).asFuture)
-
-    (for {
-      _ <- anonymiseUsername()
-      _ <- unsubscribeEmails()
-      _ <- deleteAccount()
-    } yield EmailService.sendDeletionConfirmation(request.user.email)).fold(
-        error => {
-          logger.error(s"Error deleting user $id: $error")
-          ApiError.apiErrorToResult(error)
-        },
-        _ => {
-          logger.info(s"Successfuly deleted user $id")
-          NoContent
-        }
-    )
+      case Left(r) => ApiError.apiErrorToResult(r)
+    }
   }
   
   def sendEmailValidation(id: String) = (auth andThen UserAction(id)).async { request =>

--- a/app/repositories/UsersWriteRepository.scala
+++ b/app/repositories/UsersWriteRepository.scala
@@ -110,14 +110,14 @@ class UsersWriteRepository @Inject() (salatMongoConnection: SalatMongoConnection
       "update could not be performed contact identitydev@guardian.co.uk"
   }
 
-  def delete(userId: String): Either[ApiError, Boolean] = {
+  def delete(user: User): Either[ApiError, Boolean] = {
     Try {
-      removeById(userId)
+      removeById(user.id)
     } match {
       case Success(r) =>
         Right(true)
       case Failure(t) =>
-        logger.error(s"Failed to delete user. id: $userId", t)
+        logger.error(s"Failed to delete user. id: ${user.id}", t)
         Left(ApiErrors.internalError(t.getMessage))
     }
   }

--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -109,14 +109,10 @@ class UserService @Inject() (usersReadRepository: UsersReadRepository,
     ApiResponse.Async(result)
   }
 
-  def delete(userId: String, usernameToReserve: Option[String]): ApiResponse[ReservedUsernameList] = {
-    /* FIXME: give discussion chance to update anonymised username before deletion
-       https://github.com/guardian/discussion-platform/blob/9bd52222c988af50bfbf42fa3a8369048c509114/identitysync/lambda/IdentitySync.js */
-    Thread.sleep(10000)
-
-    val result = usersWriteRepository.delete(userId) match{
+  def delete(user: User): ApiResponse[ReservedUsernameList] = {
+    val result = usersWriteRepository.delete(user) match{
       case Right(r) =>
-        usernameToReserve.map(username => reservedUserNameRepository.addReservedUsername(username)).getOrElse {
+        user.username.map(username => reservedUserNameRepository.addReservedUsername(username)).getOrElse {
           reservedUserNameRepository.loadReservedUsernames
         }
       case Left(r) => Left(r)

--- a/test/controllers/UsersControllerTest.scala
+++ b/test/controllers/UsersControllerTest.scala
@@ -155,25 +155,6 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
       val result = controller.delete(id)(FakeRequest())
       status(result) shouldEqual NOT_FOUND
     }
-
-    "return 204 when user is deleted" in {
-      val id = "abc"
-      val user = User("", "")
-      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
-      when(userService.delete(user)).thenReturn(ApiResponse.Right(ReservedUsernameList(Nil)))
-      val result = controller.delete(id)(FakeRequest())
-      status(result) shouldEqual NO_CONTENT
-    }
-
-    "return 500 when error occurs" in {
-      val id = "abc"
-      val user = User("", "")
-      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
-      when(userService.delete(user)).thenReturn(ApiResponse.Left[ReservedUsernameList](ApiErrors.internalError("boom")))
-      val result = controller.delete(id)(FakeRequest())
-      status(result) shouldEqual INTERNAL_SERVER_ERROR
-      contentAsJson(result) shouldEqual Json.toJson(ApiErrors.internalError("boom"))
-    }
   }
   
   "sendEmailValidation" should {

--- a/test/controllers/UsersControllerTest.scala
+++ b/test/controllers/UsersControllerTest.scala
@@ -155,6 +155,25 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
       val result = controller.delete(id)(FakeRequest())
       status(result) shouldEqual NOT_FOUND
     }
+
+    "return 204 when user is deleted" in {
+      val id = "abc"
+      val user = User("", "")
+      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
+      when(userService.delete(user)).thenReturn(ApiResponse.Right(ReservedUsernameList(Nil)))
+      val result = controller.delete(id)(FakeRequest())
+      status(result) shouldEqual NO_CONTENT
+    }
+
+    "return 500 when error occurs" in {
+      val id = "abc"
+      val user = User("", "")
+      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
+      when(userService.delete(user)).thenReturn(ApiResponse.Left[ReservedUsernameList](ApiErrors.internalError("boom")))
+      val result = controller.delete(id)(FakeRequest())
+      status(result) shouldEqual INTERNAL_SERVER_ERROR
+      contentAsJson(result) shouldEqual Json.toJson(ApiErrors.internalError("boom"))
+    }
   }
   
   "sendEmailValidation" should {

--- a/test/repositories/UsersRepositoryTest.scala
+++ b/test/repositories/UsersRepositoryTest.scala
@@ -227,8 +227,8 @@ class UsersRepositoryTest @Inject() (app: Application) extends PlaySpec with One
 
   "delete" should {
     "return true when successful" in {
-      val repo = Play.current.injector.instanceOf(classOf[UsersReadRepository])
-      val writeRepo = Play.current.injector.instanceOf(classOf[UsersWriteRepository])
+      val repo = app.injector.instanceOf(classOf[UsersReadRepository])
+      val writeRepo = app.injector.instanceOf(classOf[UsersWriteRepository])
       val user1 = createUser()
       val createdUser1 = writeRepo.createUser(user1)
       val origUser = User.fromPersistedUser(user1.copy(_id = createdUser1))

--- a/test/repositories/UsersRepositoryTest.scala
+++ b/test/repositories/UsersRepositoryTest.scala
@@ -227,13 +227,13 @@ class UsersRepositoryTest @Inject() (app: Application) extends PlaySpec with One
 
   "delete" should {
     "return true when successful" in {
-      val repo = app.injector.instanceOf(classOf[UsersReadRepository])
-      val writeRepo = app.injector.instanceOf(classOf[UsersWriteRepository])
+      val repo = Play.current.injector.instanceOf(classOf[UsersReadRepository])
+      val writeRepo = Play.current.injector.instanceOf(classOf[UsersWriteRepository])
       val user1 = createUser()
       val createdUser1 = writeRepo.createUser(user1)
       val origUser = User.fromPersistedUser(user1.copy(_id = createdUser1))
 
-      val result  = writeRepo.delete(origUser.id)
+      val result  = writeRepo.delete(origUser)
       result.isRight mustBe true
       Await.result(repo.findById(origUser.id), 1.second) mustEqual None
     }

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -4,7 +4,7 @@ import actors.EventPublishingActorProvider
 import models._
 import org.mockito.Mockito
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.mock.MockitoSugar
 import repositories.{PersistedUserUpdate, ReservedUserNameWriteRepository, UsersWriteRepository, UsersReadRepository}
 
 import scala.concurrent.{Await, Future}
@@ -185,27 +185,27 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
     "remove the given user and reserve username" in {
       val username = "testuser"
       val user = User("id", "email", username = Some(username))
-      when(userWriteRepo.delete(user.id)).thenReturn(Right(true))
+      when(userWriteRepo.delete(user)).thenReturn(Right(true))
       when(reservedUsernameRepo.addReservedUsername(username)).thenReturn(Right(ReservedUsernameList(List(username))))
-      val result = service.delete(user.id, user.username)
+      val result = service.delete(user)
 
       Await.result(result.underlying, 1.second) shouldEqual Right(ReservedUsernameList(List(username)))
     }
 
     "remove the given user and return existing reserved usernames when user has no username" in {
       val user = User("id", "email", username = None)
-      when(userWriteRepo.delete(user.id)).thenReturn(Right(true))
+      when(userWriteRepo.delete(user)).thenReturn(Right(true))
       when(reservedUsernameRepo.loadReservedUsernames).thenReturn(Right(ReservedUsernameList(Nil)))
-      val result = service.delete(user.id, user.username)
+      val result = service.delete(user)
 
       Await.result(result.underlying, 1.second) shouldEqual Right(ReservedUsernameList(Nil))
     }
 
     "return internal server api error if an error occurs deleting the user" in {
       val user = User("id", "email")
-      when(userWriteRepo.delete(user.id)).thenReturn(Left(ApiErrors.internalError("boom")))
+      when(userWriteRepo.delete(user)).thenReturn(Left(ApiErrors.internalError("boom")))
 
-      val result = service.delete(user.id, user.username)
+      val result = service.delete(user)
 
       Await.result(result.underlying, 1.second) shouldEqual Left(ApiErrors.internalError("boom"))
     }

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -4,7 +4,7 @@ import actors.EventPublishingActorProvider
 import models._
 import org.mockito.Mockito
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import repositories.{PersistedUserUpdate, ReservedUserNameWriteRepository, UsersWriteRepository, UsersReadRepository}
 
 import scala.concurrent.{Await, Future}


### PR DESCRIPTION
Moderation does not want usernames to be anonymised on deletion.

This reverts https://github.com/guardian/identity-admin-api/pull/84