### PR TITLE
Speed up search

### DIFF
--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -50,6 +50,7 @@ trait SalesforceService {
 class Salesforce @Inject() (ws: WSClient) extends SalesforceService with Logging {
 
   private lazy val sfAuth: SFAuthentication = {
+    logger.info("Authenticating with Salesforce...")
     val authEndpoint = s"${apiUrl}/services/oauth2/token"
 
     val param = Map(


### PR DESCRIPTION
HTTP request to search Salesforce by membership number takes up to 10 seconds to complete (which is strange because against UAT the same query is almost instant). Thus execute Salesforce search only if nothing is found in Identity, until we figure out why searching by membership number is so slow. It is possible that search by membership number is indexed in UAT but not PROD.

| Search by      | Time (s)         |
| ------------- | ------------- |
| Membership_Number__c  | 9.5 |
| IdentityID__c                      | 0.1 |
| Subscription_Name__c     | 0.1 |