### PR TITLE
Sync Jobs user changes to Madgex

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -63,6 +63,6 @@ object Config {
   }
 
   object Madgex {
-    val apiUrl = config.getString("madgex.api.url")
+    val apiUrl = config.getString("madgex.host")
   }
 }

--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -61,4 +61,8 @@ object Config {
   object Discussion {
     val apiUrl = config.getString("discussion.api.url")
   }
+
+  object Madgex {
+    val apiUrl = config.getString("madgex.api.url")
+  }
 }

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -41,7 +41,7 @@ object UserStatus {
 
 case class UserGroup(packageCode: String,
                      path:String,
-                     joinDate: Option[DateTime])
+                     joinDate: Option[DateTime] = None)
 
 object UserGroup {
   implicit val format = Json.format[UserGroup]
@@ -165,3 +165,14 @@ object User {
                 socialLinks = user.socialLinks.map(s => SocialLink(s.socialId, s.network))
     )
 }
+
+case class GNMMadgexUser(id: String,
+                         madgexUser: MadgexUser
+                        )
+
+case class MadgexUser(primaryEmailAddress: String,
+                      firstName: Option[String] = None,
+                      secondName: Option[String] = None,
+                      receive3rdPartyMarketing: Boolean = false,
+                      receiveGnmMarketing: Boolean = false
+                     )

--- a/app/services/MadgexService.scala
+++ b/app/services/MadgexService.scala
@@ -5,7 +5,7 @@ import javax.inject.{Inject, Singleton}
 import com.gu.identity.util.Logging
 import configuration.Config
 import util.UserConverter._
-import models.{GNMMadgexUser, MadgexUser, User}
+import models.{GNMMadgexUser, MadgexUser}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 
@@ -17,20 +17,17 @@ import play.api.libs.json.Json
 
   implicit val format = Json.format[MadgexUser]
 
-  def update(user: GNMMadgexUser): Future[Boolean] = {
+  def update(user: GNMMadgexUser): Future[Unit] = {
     val id = user.id
     requestSigner.sign(ws.url(s"${Config.Madgex.apiUrl}/updatessouser/$id"))
       .post(Json.toJson(user.madgexUser))
-      .map { response =>
-        response.status match {
-          case 200 => true
-          case 401 => logger.error("Failed to authenticate with Madgex API.")
-            false
-          case status => logger.error(s"Unexpected status code:  $status from Madgex API")
-            false
-        }
-      }.recover { case t: Throwable => logger.error("Error when updating Madgex", t)
-      false
+      .map { _.status match {
+        case 200 =>
+        case 401 => logger.error("Failed to authenticate with Madgex API.")
+        case status => logger.error(s"Unexpected status code:  $status from Madgex API")
+      }
+      }.recover {
+      case t: Throwable => logger.error("Error when updating Madgex", t)
     }
   }
 }

--- a/app/services/MadgexService.scala
+++ b/app/services/MadgexService.scala
@@ -4,6 +4,7 @@ import javax.inject.{Inject, Singleton}
 
 import com.gu.identity.util.Logging
 import configuration.Config
+import util.UserConverter._
 import models.{GNMMadgexUser, MadgexUser, User}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
@@ -33,15 +34,8 @@ import play.api.libs.json.Json
     }
   }
 
-  def update(user: User): Future[Boolean] = {
+  def update(user: GNMMadgexUser): Future[Boolean] = {
     sendUpdate(user)
   }
-
-  implicit def toMadgexUser(user: User): GNMMadgexUser = {
-    GNMMadgexUser(user.id, MadgexUser(user.email, user.personalDetails.firstName, user.personalDetails.lastName,
-      user.status.receive3rdPartyMarketing.getOrElse(false), user.status.receiveGnmMarketing.getOrElse(false))
-    )
-  }
-
 }
 

--- a/app/services/MadgexService.scala
+++ b/app/services/MadgexService.scala
@@ -17,7 +17,7 @@ import play.api.libs.json.Json
 
   implicit val format = Json.format[MadgexUser]
 
-  def sendUpdate(user: GNMMadgexUser): Future[Boolean] = {
+  def update(user: GNMMadgexUser): Future[Boolean] = {
     val id = user.id
     requestSigner.sign(ws.url(s"${Config.Madgex.apiUrl}/updatessouser/$id"))
       .post(Json.toJson(user.madgexUser))
@@ -32,10 +32,6 @@ import play.api.libs.json.Json
       }.recover { case t: Throwable => logger.error("Error when updating Madgex", t)
       false
     }
-  }
-
-  def update(user: GNMMadgexUser): Future[Boolean] = {
-    sendUpdate(user)
   }
 }
 

--- a/app/services/MadgexService.scala
+++ b/app/services/MadgexService.scala
@@ -1,0 +1,47 @@
+package services
+
+import javax.inject.{Inject, Singleton}
+
+import com.gu.identity.util.Logging
+import configuration.Config
+import models.{GNMMadgexUser, MadgexUser, User}
+import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
+
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scala.concurrent.Future
+import play.api.libs.json.Json
+
+@Singleton class MadgexService @Inject() (ws: WSClient, requestSigner: RequestSigner) extends Logging {
+
+  implicit val format = Json.format[MadgexUser]
+
+  def sendUpdate(user: GNMMadgexUser): Future[Boolean] = {
+    val id = user.id
+    requestSigner.sign(ws.url(s"${Config.Madgex.apiUrl}/updatessouser/$id"))
+      .post(Json.toJson(user.madgexUser))
+      .map { response =>
+        response.status match {
+          case 200 => true
+          case 401 => logger.error("Failed to authenticate with Madgex API.")
+            false
+          case status => logger.error(s"Unexpected status code:  $status from Madgex API")
+            false
+        }
+      }.recover { case t: Throwable => logger.error("Error when updating Madgex", t)
+      false
+    }
+  }
+
+  def update(user: User): Future[Boolean] = {
+    sendUpdate(user)
+  }
+
+  implicit def toMadgexUser(user: User): GNMMadgexUser = {
+    GNMMadgexUser(user.id, MadgexUser(user.email, user.personalDetails.firstName, user.personalDetails.lastName,
+      user.status.receive3rdPartyMarketing.getOrElse(false), user.status.receiveGnmMarketing.getOrElse(false))
+    )
+  }
+
+}
+

--- a/app/services/RequestSigner.scala
+++ b/app/services/RequestSigner.scala
@@ -15,7 +15,7 @@ import play.api.libs.ws.{WSClient, WSRequest}
 import util.Formats
 
 @Singleton class RequestSignerWithSecret @Inject()(configuration: Configuration) extends RequestSigner {
-  val secret = configuration.getString("identity-admin.adminApi.secret").get
+  val secret = configuration.getString("madgex.secret").get
 }
 
 @ImplementedBy(classOf[RequestSignerWithSecret])

--- a/app/services/RequestSigner.scala
+++ b/app/services/RequestSigner.scala
@@ -1,0 +1,60 @@
+package services
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+import com.google.inject.ImplementedBy
+import com.gu.identity.util.Logging
+import org.apache.commons.codec.binary.Base64
+import org.joda.time.DateTime
+import play.api.Play._
+import play.api.http.HeaderNames
+import play.api.libs.ws.WSRequest
+import util.Formats
+
+class RequestSignerWithSecret extends RequestSigner {
+  val secret = current.configuration.getString("identity-admin.adminApi.secret").get
+}
+
+@ImplementedBy(classOf[RequestSignerWithSecret])
+trait RequestSigner extends Logging {
+
+  def secret: String
+
+  private val ALGORITHM = "HmacSHA256"
+  private def hmacHeaderValue(hmacToken: String) = s"HMAC $hmacToken"
+
+  def sign(request: WSRequest): WSRequest = {
+    val path = getPath(request)
+    val dateHeaderValue = getDateHeaderValue
+    val hmacToken = sign(dateHeaderValue, path)
+    logger.info(s"path: $path, date: $dateHeaderValue, hmac: $hmacToken")
+    request.withHeaders(HeaderNames.DATE -> dateHeaderValue, HeaderNames.AUTHORIZATION -> hmacHeaderValue(hmacToken))
+  }
+
+  private[services] def getPath(request: WSRequest): String = {
+    val uri = request.uri
+    val queryString = uri.getRawQuery
+    if(queryString == null || queryString.isEmpty) uri.getPath else s"${uri.getPath}?" + queryString.replace("+", "%20")
+  }
+
+  private[services] def getDateHeaderValue: String = {
+    val now = DateTime.now()
+    Formats.toHttpDateTimeString(now)
+  }
+
+  private[services] def sign(date: String, path: String): String = {
+    val input = List[String](date, path)
+    val toSign = input.mkString("\n")
+    calculateHMAC(toSign)
+  }
+
+  private def calculateHMAC(toEncode: String): String = {
+    val signingKey = new SecretKeySpec(secret.getBytes, ALGORITHM)
+    val mac = Mac.getInstance(ALGORITHM)
+    mac.init(signingKey)
+    val rawHmac = mac.doFinal(toEncode.getBytes)
+    new String(Base64.encodeBase64(rawHmac))
+  }
+
+}

--- a/app/services/RequestSigner.scala
+++ b/app/services/RequestSigner.scala
@@ -2,18 +2,20 @@ package services
 
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
+import javax.inject.{Inject, Singleton}
 
 import com.google.inject.ImplementedBy
 import com.gu.identity.util.Logging
 import org.apache.commons.codec.binary.Base64
 import org.joda.time.DateTime
+import play.api.Configuration
 import play.api.Play._
 import play.api.http.HeaderNames
-import play.api.libs.ws.WSRequest
+import play.api.libs.ws.{WSClient, WSRequest}
 import util.Formats
 
-class RequestSignerWithSecret extends RequestSigner {
-  val secret = current.configuration.getString("identity-admin.adminApi.secret").get
+@Singleton class RequestSignerWithSecret @Inject()(configuration: Configuration) extends RequestSigner {
+  val secret = configuration.getString("identity-admin.adminApi.secret").get
 }
 
 @ImplementedBy(classOf[RequestSignerWithSecret])
@@ -40,7 +42,7 @@ trait RequestSigner extends Logging {
 
   private[services] def getDateHeaderValue: String = {
     val now = DateTime.now()
-    Formats.toHttpDateTimeString(now)
+    Formats.toMadgexDateTimeString(now)
   }
 
   private[services] def sign(date: String, path: String): String = {

--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -61,8 +61,7 @@ class UserService @Inject() (usersReadRepository: UsersReadRepository,
         }
 
         if (isJobsUser(user) && isJobsUserChanged(user, userUpdateRequest)) {
-          val gNMMadgexUser = GNMMadgexUser(user.id, userUpdateRequest)
-          madgexService.update(gNMMadgexUser)
+          madgexService.update(GNMMadgexUser(user.id, userUpdateRequest))
         }
 
         ApiResponse.Async(Future.successful(result))

--- a/app/util/Formats.scala
+++ b/app/util/Formats.scala
@@ -1,7 +1,8 @@
 package util
 
 import com.github.nscala_time.time.Imports._
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.DateTimeFormat
 
 object Formats {
 
@@ -10,4 +11,10 @@ object Formats {
 
   def toHttpDateTimeString(dateTime: DateTime): String = dateTime.withZone(DateTimeZone.forID("GMT")).toString(Formats.HTTPDateFormat)
   def toDateTime(date: String): DateTime = HTTPDateFormat.parseDateTime(date)
+
+  val MadgexDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss").withZone(DateTimeZone.forID("Europe/London"))
+
+  def toMadgexDateTimeString(dateTime: DateTime): String = dateTime.withZone(DateTimeZone.forID("Europe/London")).toString(Formats.MadgexDateFormat)
+  def toMadgexDateTime(date: String): DateTime = MadgexDateFormat.parseDateTime(date)
 }
+

--- a/app/util/UserConverter.scala
+++ b/app/util/UserConverter.scala
@@ -1,0 +1,21 @@
+package util
+
+import models.{GNMMadgexUser, MadgexUser, User, UserUpdateRequest}
+
+object UserConverter{
+
+  implicit def toGNMMadgexUser(user: User): GNMMadgexUser = {
+    GNMMadgexUser(user.id, MadgexUser(user.email, user.personalDetails.firstName, user.personalDetails.lastName,
+      user.status.receive3rdPartyMarketing.getOrElse(false), user.status.receiveGnmMarketing.getOrElse(false))
+    )
+  }
+
+  implicit def toMadgexUser(user: User): MadgexUser =
+    MadgexUser(user.email, user.personalDetails.firstName, user.personalDetails.lastName,
+      user.status.receive3rdPartyMarketing.getOrElse(false), user.status.receiveGnmMarketing.getOrElse(false))
+
+  implicit def toMadgexUser(user: UserUpdateRequest): MadgexUser =
+    MadgexUser(user.email, user.firstName, user.lastName,
+      user.receive3rdPartyMarketing.getOrElse(false), user.receiveGnmMarketing.getOrElse(false))
+
+}

--- a/conf/CODE.conf
+++ b/conf/CODE.conf
@@ -9,3 +9,5 @@ monitoring {
 }
 
 discussion.api.url = "https://discussion.code.dev-theguardian.com/discussion-api"
+
+madgex.api.url="https://guardianjobs-web.madgexjbtest.com"

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -23,3 +23,5 @@ events {
 }
 
 discussion.api.url = "https://discussion.thegulocal.com"
+
+madgex.api.url="https://guardianjobs-web.madgexjbtest.com"

--- a/conf/PROD.conf
+++ b/conf/PROD.conf
@@ -12,3 +12,5 @@ monitoring {
 }
 
 discussion.api.url = "https://discussion.theguardian.com/discussion-api"
+
+madgex.api.url="https://jobs.theguardian.com"

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -127,7 +127,6 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
       when(userWriteRepo.update(user, updateRequest)).thenReturn(Right(updatedUser))
       when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(Right(true)))
-      when(madgexService.update(gNMMadgexUser)).thenReturn(Future.successful(true))
 
       val result = service.update(user, userUpdateRequest)
 

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -21,8 +21,10 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
   val eventPublishingActorProvider = mock[EventPublishingActorProvider]
   val deletedUsersRepository = mock[DeletedUsersRepository]
   val salesforceService = mock[SalesforceService]
+  val madgexService = mock[MadgexService]
   val service =
-    spy(new UserService(userReadRepo, userWriteRepo, reservedUsernameRepo, identityApiClient, eventPublishingActorProvider, deletedUsersRepository, salesforceService))
+    spy(new UserService(userReadRepo, userWriteRepo, reservedUsernameRepo, identityApiClient,
+      eventPublishingActorProvider, deletedUsersRepository, salesforceService, madgexService))
 
   before {
     Mockito.reset(userReadRepo, userWriteRepo, reservedUsernameRepo, identityApiClient, eventPublishingActorProvider, service)
@@ -63,6 +65,18 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
     "return false if a zero length username is being added" in {
       service.isDisplayNameChanged(None, None) should be(false)
       service.isDisplayNameChanged(None, Some("existingDisplayName")) should be(true)
+    }
+  }
+
+  "isJobsUser" should {
+    "return true for a jobs user" in {
+      val user = User("id", "email@theguardian.com",groups = Seq(UserGroup( "GRS", "/sys/policies/guardian-jobs")))
+      service.isJobsUser(user) should be(true)
+    }
+
+    "return true for a non-jobs user" in {
+      val user = User("id", "email@theguardian.com")
+      service.isJobsUser(user) should be(false)
     }
   }
 


### PR DESCRIPTION
This PR matches the Identity API changes in [642](https://github.com/guardian/identity/pull/642) thus ensuring that any attribute changes to user accounts in the admin tool are replicated in the Madgex system.  This is particularly pertinent for marketing preference changes.  

I have tested this on PROD as testing on CODE was blocked due to basic auth being enabled on the [jobs](http://jobs.code.dev-theguardian.com/) site on CODE.  This blocks testing as the API also requires basic auth whereas PROD doesn't.  I have asked Madgex to disable this for testing but they have been slow to respond.