### PR TITLE
Add editorial email subscriptions

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -54,8 +54,14 @@ object Config {
   }
 
   object ExactTarget {
-    val clientSecret = config.getString("exacttarget.clientSecret")
-    val clientId = config.getString("exacttarget.clientId")
+    object Admin {
+      val clientSecret = config.getString("exacttarget.admin.clientSecret")
+      val clientId = config.getString("exacttarget.admin.clientId")
+    }
+    object Editorial {
+      val clientSecret = config.getString("exacttarget.editorial.clientSecret")
+      val clientId = config.getString("exacttarget.editorial.clientId")
+    }
   }
 
   object Discussion {

--- a/app/controllers/UsersController.scala
+++ b/app/controllers/UsersController.scala
@@ -58,14 +58,14 @@ class UsersController @Inject() (
       val subscriptionF = salesforce.getSubscriptionByIdentityId(userId)
       val membershipF = salesforce.getMembershipByIdentityId(userId)
       val hasCommentedF = discussionService.hasCommented(userId)
-      val emailSubsF = exactTargetService.listOfSubscriptions(userId)
+      val newsletterSubsF = exactTargetService.newsletterSubscriptions(userId)
 
       for {
         user <- userService.findById(userId).asFuture
         subscription <- subscriptionF
         membership <- membershipF
         hasCommented <- hasCommentedF
-        emailSubs <- emailSubsF
+        newsletterSubs <- newsletterSubsF
       } yield {
         user match {
           case Left(r) => Left(ApiError.apiErrorToResult(r))
@@ -77,7 +77,7 @@ class UsersController @Inject() (
               subscriptionDetails = subscription,
               membershipDetails = membership,
               hasCommented = hasCommented,
-              emailSubscriptions = emailSubs)
+              newsletterSubscriptions = newsletterSubs)
 
             Right(new UserRequest(userWithSubscriptions, input))
         }

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -95,6 +95,7 @@ case class User(id: String,
                 socialLinks: Seq[SocialLink] = Nil,
                 membershipDetails: Option[SalesforceSubscription] = None,
                 subscriptionDetails: Option[SalesforceSubscription] = None,
+                emailSubscriptions: List[String] = Nil,
                 hasCommented: Boolean = false,
                 deleted: Boolean = false,
                 orphan: Boolean = false

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -95,7 +95,7 @@ case class User(id: String,
                 socialLinks: Seq[SocialLink] = Nil,
                 membershipDetails: Option[SalesforceSubscription] = None,
                 subscriptionDetails: Option[SalesforceSubscription] = None,
-                emailSubscriptions: List[String] = Nil,
+                newsletterSubscriptions: List[String] = Nil,
                 hasCommented: Boolean = false,
                 deleted: Boolean = false,
                 orphan: Boolean = false

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -63,7 +63,7 @@ class ExactTargetService @Inject() (usersReadRepository: UsersReadRepository) ex
         val response = etClientEditorial.retrieve(classOf[ETSubscriber], s"key=${user.email}")
         Option(response.getResult).fold[List[String]]
           { Nil }
-          { result => result.getObject.getSubscriptions.toList.map(_.getListId) }
+          { _.getObject.getSubscriptions.toList.filter(_.getStatus == ETSubscriber.Status.ACTIVE).map(_.getListId) }
       },
       Nil
     )

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -1,14 +1,21 @@
 package services
 
-import com.exacttarget.fuelsdk.{ETClient, ETConfiguration, ETResponse, ETSubscriber}
+import javax.inject.{Inject, Singleton}
+
+import com.exacttarget.fuelsdk._
 import com.gu.identity.util.Logging
 import configuration.Config
 
 import scala.concurrent.Future
-import scalaz.\/
+import scalaz.std.scalaFuture._
+import scalaz.{OptionT, \/}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import repositories.UsersReadRepository
 
-object ExactTargetService extends Logging {
+import scala.collection.JavaConversions._
+
+@Singleton
+class ExactTargetService @Inject() (usersReadRepository: UsersReadRepository) extends Logging {
 
   type UnsubscribeError = ETResponse[ETSubscriber]
 
@@ -17,7 +24,7 @@ object ExactTargetService extends Logging {
 
     def unsubscribe(subscriber: ETSubscriber) = {
       subscriber.setStatus(ETSubscriber.Status.UNSUBSCRIBED)
-      val response = etClient.update(subscriber)
+      val response = etClientAdmin.update(subscriber)
 
       Option(response.getResult).fold[UnsubscribeError \/ ETSubscriber]
         {\/.left(response)}
@@ -29,7 +36,7 @@ object ExactTargetService extends Logging {
       subscriber.setEmailAddress(email)
       subscriber.setKey(email)
       subscriber.setStatus(ETSubscriber.Status.UNSUBSCRIBED)
-      val response = etClient.create(subscriber)
+      val response = etClientAdmin.create(subscriber)
 
       Option(response.getResult).fold[UnsubscribeError \/ ETSubscriber]
         {\/.left(response)}
@@ -37,23 +44,41 @@ object ExactTargetService extends Logging {
     }
 
     Option(
-      etClient.retrieve(classOf[ETSubscriber], s"emailAddress=$email").getResult
+      etClientAdmin.retrieve(classOf[ETSubscriber], s"emailAddress=$email").getResult
     ).fold(createAndUnsubscribe)(result => unsubscribe(result.getObject))
   }
 
   def updateEmailAddress(oldEmail: String, newEmail: String) = Future {
     logger.info("Updating user's email address in ExactTarget")
-    Option(etClient.retrieve(classOf[ETSubscriber], s"emailAddress=$oldEmail").getResult).map { result =>
+    Option(etClientAdmin.retrieve(classOf[ETSubscriber], s"emailAddress=$oldEmail").getResult).map { result =>
       val subscriber = result.getObject
       subscriber.setEmailAddress(newEmail)
-      etClient.update(subscriber)
+      etClientAdmin.update(subscriber)
     }
   }
 
-  private lazy val etClient = {
+  def listOfSubscriptions(identityId: String): Future[List[String]] =
+    OptionT(usersReadRepository.findById(identityId)).fold(
+      user => {
+        val response = etClientEditorial.retrieve(classOf[ETSubscriber], s"key=${user.email}")
+        Option(response.getResult).fold[List[String]]
+          { Nil }
+          { result => result.getObject.getSubscriptions.toList.map(_.getListId) }
+      },
+      Nil
+    )
+
+  private lazy val etClientAdmin = {
     val etConf = new ETConfiguration()
-    etConf.set("clientId", Config.ExactTarget.clientId)
-    etConf.set("clientSecret", Config.ExactTarget.clientSecret)
+    etConf.set("clientId", Config.ExactTarget.Admin.clientId)
+    etConf.set("clientSecret", Config.ExactTarget.Admin.clientSecret)
+    new ETClient(etConf)
+  }
+
+  private lazy val etClientEditorial = {
+    val etConf = new ETConfiguration()
+    etConf.set("clientId", Config.ExactTarget.Editorial.clientId)
+    etConf.set("clientSecret", Config.ExactTarget.Editorial.clientSecret)
     new ETClient(etConf)
   }
 }

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -57,7 +57,7 @@ class ExactTargetService @Inject() (usersReadRepository: UsersReadRepository) ex
     }
   }
 
-  def listOfSubscriptions(identityId: String): Future[List[String]] =
+  def newsletterSubscriptions(identityId: String): Future[List[String]] =
     OptionT(usersReadRepository.findById(identityId)).fold(
       user => {
         val response = etClientEditorial.retrieve(classOf[ETSubscriber], s"key=${user.email}")

--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -25,7 +25,8 @@ class UserService @Inject() (usersReadRepository: UsersReadRepository,
                              eventPublishingActorProvider: EventPublishingActorProvider,
                              deletedUsersRepository: DeletedUsersRepository,
                              salesforceService: SalesforceService,
-                             madgexService: MadgexService) extends Logging {
+                             madgexService: MadgexService,
+                             exactTargetService: ExactTargetService) extends Logging {
 
   private lazy val UsernamePattern = "[a-zA-Z0-9]{6,20}".r
 
@@ -52,7 +53,7 @@ class UserService @Inject() (usersReadRepository: UsersReadRepository,
 
         if(result.isRight && userEmailChanged) {
           identityApiClient.sendEmailValidation(user.id)
-          ExactTargetService.updateEmailAddress(user.email, userUpdateRequest.email)
+          exactTargetService.updateEmailAddress(user.email, userUpdateRequest.email)
         }
 
         if (userEmailChanged && eventsEnabled) {

--- a/test/controllers/UsersControllerTest.scala
+++ b/test/controllers/UsersControllerTest.scala
@@ -12,16 +12,20 @@ import play.api.mvc.Results._
 import play.api.test.FakeRequest
 import repositories.IdentityUser
 import play.api.test.Helpers._
-import services.{DiscussionService, SalesforceService, UserService}
+import services.{DiscussionService, ExactTargetService, SalesforceService, UserService}
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
+  
+  val testIdentityId = "abc"
 
   val userService = mock[UserService]
   val dapiWsMockurl = s"/profile/10000001/stats"
   val dapiWsMock = MockWS { case (GET, dapiWsMockurl) => Action {Ok("""{"status":"ok","comments":0,"pickedComments":0}""")}}
+  val exactTargetServiceMock = mock[ExactTargetService]
+  when(exactTargetServiceMock.listOfSubscriptions("abc")).thenReturn(Future.successful(Nil))
 
   class StubAuthenticatedAction extends AuthenticatedAction {
     val secret = "secret"
@@ -40,7 +44,8 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
     override def getMembershipBySubscriptionId(subscriptionId: String): Future[Option[SalesforceSubscription]] = Future(None)
   }
 
-  val controller = new UsersController(userService, new StubAuthenticatedAction, new StubSalesfroce, new DiscussionService(dapiWsMock))
+  val controller = new UsersController(
+    userService, new StubAuthenticatedAction, new StubSalesfroce, new DiscussionService(dapiWsMock), exactTargetServiceMock)
 
   "search" should {
     "return 400 when query string is less than minimum length" in {
@@ -98,18 +103,16 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
 
   "findById" should {
     "return 404 when user not found" in {
-      val id = "abc"
-      when(userService.findById(id)).thenReturn(ApiResponse.Left[User](ApiErrors.notFound))
-      val result = controller.findById(id)(FakeRequest())
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Left[User](ApiErrors.notFound))
+      val result = controller.findById(testIdentityId)(FakeRequest())
       status(result) shouldEqual NOT_FOUND
       contentAsJson(result) shouldEqual Json.toJson(ApiErrors.notFound)
     }
 
     "return 200 when user found" in {
-      val id = "abc"
-      val user = User(id, "test@test.com")
-      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
-      val result = controller.findById(id)(FakeRequest())
+      val user = User(testIdentityId, "test@test.com")
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Right(user))
+      val result = controller.findById(testIdentityId)(FakeRequest())
       status(result) shouldEqual OK
       contentAsJson(result) shouldEqual Json.toJson(user)
     }
@@ -117,37 +120,33 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
 
   "update" should {
     "return 400 when json is invalid" in {
-      val id = "abc"
       val json = """{"key":"value"}"""
-      val result = controller.update(id)(FakeRequest().withBody(Json.parse(json)))
+      val result = controller.update(testIdentityId)(FakeRequest().withBody(Json.parse(json)))
       status(result) shouldEqual BAD_REQUEST
     }
 
     "return 404 when user is not found" in {
-      val id = "abc"
       val userUpdateRequest = UserUpdateRequest(email = "test@test.com", username = Some("username"))
-      when(userService.findById(id)).thenReturn(ApiResponse.Left[User](ApiErrors.notFound))
-      val result = controller.update(id)(FakeRequest().withBody(Json.toJson(userUpdateRequest)))
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Left[User](ApiErrors.notFound))
+      val result = controller.update(testIdentityId)(FakeRequest().withBody(Json.toJson(userUpdateRequest)))
       status(result) shouldEqual NOT_FOUND
     }
 
     "return 400 when username and display name differ in request" in {
-      val id = "abc"
       val userUpdateRequest = UserUpdateRequest(email = "test@test.com", username = Some("username"), displayName = Some("displayname"))
       val user = User("id", "email")
-      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Right(user))
       when(userService.update(user, userUpdateRequest)).thenReturn(ApiResponse.Right(user))
-      val result = controller.update(id)(FakeRequest().withBody(Json.toJson(userUpdateRequest)))
+      val result = controller.update(testIdentityId)(FakeRequest().withBody(Json.toJson(userUpdateRequest)))
       status(result) shouldEqual BAD_REQUEST
     }
 
     "return 200 with updated user when update is successful" in {
-      val id = "abc"
       val userUpdateRequest = UserUpdateRequest(email = "test@test.com", username = Some("username"))
       val user = User("id", "email")
-      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Right(user))
       when(userService.update(user, userUpdateRequest)).thenReturn(ApiResponse.Right(user))
-      val result = controller.update(id)(FakeRequest().withBody(Json.toJson(userUpdateRequest)))
+      val result = controller.update(testIdentityId)(FakeRequest().withBody(Json.toJson(userUpdateRequest)))
       status(result) shouldEqual OK
       contentAsJson(result) shouldEqual Json.toJson(user)
     }
@@ -155,36 +154,32 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
 
   "delete" should {
     "return 404 when user is not found" in {
-      val id = "abc"
-      when(userService.findById(id)).thenReturn(ApiResponse.Left[User](ApiErrors.notFound))
-      val result = controller.delete(id)(FakeRequest())
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Left[User](ApiErrors.notFound))
+      val result = controller.delete(testIdentityId)(FakeRequest())
       status(result) shouldEqual NOT_FOUND
     }
   }
   
   "sendEmailValidation" should {
     "return 404 when user is not found" in {
-      val id = "abc"
-      when(userService.findById(id)).thenReturn(ApiResponse.Left[User](ApiErrors.notFound))
-      val result = controller.sendEmailValidation(id)(FakeRequest())
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Left[User](ApiErrors.notFound))
+      val result = controller.sendEmailValidation(testIdentityId)(FakeRequest())
       status(result) shouldEqual NOT_FOUND
     }
 
     "return 204 when email validation is sent" in {
-      val id = "abc"
       val user = User("", "")
-      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Right(user))
       when(userService.sendEmailValidation(user)).thenReturn(ApiResponse.Right(true))
-      val result = controller.sendEmailValidation(id)(FakeRequest())
+      val result = controller.sendEmailValidation(testIdentityId)(FakeRequest())
       status(result) shouldEqual NO_CONTENT
     }
 
     "return 500 when error occurs" in {
-      val id = "abc"
       val user = User("", "")
-      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Right(user))
       when(userService.sendEmailValidation(user)).thenReturn(ApiResponse.Left[Boolean](ApiErrors.internalError("boom")))
-      val result = controller.sendEmailValidation(id)(FakeRequest())
+      val result = controller.sendEmailValidation(testIdentityId)(FakeRequest())
       status(result) shouldEqual INTERNAL_SERVER_ERROR
       contentAsJson(result) shouldEqual Json.toJson(ApiErrors.internalError("boom"))
     }
@@ -192,27 +187,24 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
 
   "validateEmail" should {
     "return 404 when user is not found" in {
-      val id = "abc"
-      when(userService.findById(id)).thenReturn(ApiResponse.Left[User](ApiErrors.notFound))
-      val result = controller.validateEmail(id)(FakeRequest())
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Left[User](ApiErrors.notFound))
+      val result = controller.validateEmail(testIdentityId)(FakeRequest())
       status(result) shouldEqual NOT_FOUND
     }
 
     "return 204 when email is validated" in {
-      val id = "abc"
       val user = User("", "")
-      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Right(user))
       when(userService.validateEmail(user)).thenReturn(ApiResponse.Right(true))
-      val result = controller.validateEmail(id)(FakeRequest())
+      val result = controller.validateEmail(testIdentityId)(FakeRequest())
       status(result) shouldEqual NO_CONTENT
     }
 
     "return 500 when error occurs" in {
-      val id = "abc"
       val user = User("", "")
-      when(userService.findById(id)).thenReturn(ApiResponse.Right(user))
+      when(userService.findById(testIdentityId)).thenReturn(ApiResponse.Right(user))
       when(userService.validateEmail(user)).thenReturn(ApiResponse.Left[Boolean](ApiErrors.internalError("boom")))
-      val result = controller.validateEmail(id)(FakeRequest())
+      val result = controller.validateEmail(testIdentityId)(FakeRequest())
       status(result) shouldEqual INTERNAL_SERVER_ERROR
       contentAsJson(result) shouldEqual Json.toJson(ApiErrors.internalError("boom"))
     }

--- a/test/controllers/UsersControllerTest.scala
+++ b/test/controllers/UsersControllerTest.scala
@@ -25,7 +25,7 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
   val dapiWsMockurl = s"/profile/10000001/stats"
   val dapiWsMock = MockWS { case (GET, dapiWsMockurl) => Action {Ok("""{"status":"ok","comments":0,"pickedComments":0}""")}}
   val exactTargetServiceMock = mock[ExactTargetService]
-  when(exactTargetServiceMock.listOfSubscriptions("abc")).thenReturn(Future.successful(Nil))
+  when(exactTargetServiceMock.newsletterSubscriptions("abc")).thenReturn(Future.successful(Nil))
 
   class StubAuthenticatedAction extends AuthenticatedAction {
     val secret = "secret"

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -25,9 +25,10 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
   val deletedUsersRepository = mock[DeletedUsersRepository]
   val salesforceService = mock[SalesforceService]
   val madgexService = mock[MadgexService]
+  val exactTargetService = mock[ExactTargetService]
   val service =
     spy(new UserService(userReadRepo, userWriteRepo, reservedUsernameRepo, identityApiClient,
-      eventPublishingActorProvider, deletedUsersRepository, salesforceService, madgexService))
+      eventPublishingActorProvider, deletedUsersRepository, salesforceService, madgexService, exactTargetService))
 
   before {
     Mockito.reset(userReadRepo, userWriteRepo, reservedUsernameRepo, identityApiClient, eventPublishingActorProvider, service, madgexService)


### PR DESCRIPTION
We can now query the list of all editorial newsletter subscriptions the user is subscribed to.

There is a new marketing cloud client for editorial business unit which is defined using subscription.dev marketing app center and userhelp marketing cloud credentials.