### PR TITLE
Add ExactTarget subscriber status

### DIFF
--- a/app/controllers/UsersController.scala
+++ b/app/controllers/UsersController.scala
@@ -58,14 +58,14 @@ class UsersController @Inject() (
       val subscriptionF = salesforce.getSubscriptionByIdentityId(userId)
       val membershipF = salesforce.getMembershipByIdentityId(userId)
       val hasCommentedF = discussionService.hasCommented(userId)
-      val newsletterSubsF = exactTargetService.newsletterSubscriptions(userId)
+      val newslettersSubF = exactTargetService.newslettersSubscription(userId)
 
       for {
         user <- userService.findById(userId).asFuture
         subscription <- subscriptionF
         membership <- membershipF
         hasCommented <- hasCommentedF
-        newsletterSubs <- newsletterSubsF
+        newslettersSub <- newslettersSubF
       } yield {
         user match {
           case Left(r) => Left(ApiError.apiErrorToResult(r))
@@ -77,7 +77,7 @@ class UsersController @Inject() (
               subscriptionDetails = subscription,
               membershipDetails = membership,
               hasCommented = hasCommented,
-              newsletterSubscriptions = newsletterSubs)
+              newslettersSubscription = newslettersSub)
 
             Right(new UserRequest(userWithSubscriptions, input))
         }

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -77,6 +77,12 @@ object SalesforceSubscription {
   implicit val format = Json.format[SalesforceSubscription]
 }
 
+case class NewslettersSubscription(status: String, list: List[String])
+
+object NewslettersSubscription {
+  implicit val format = Json.format[NewslettersSubscription]
+}
+
 case class User(id: String,
                 email: String,
                 displayName: Option[String] = None,
@@ -95,7 +101,7 @@ case class User(id: String,
                 socialLinks: Seq[SocialLink] = Nil,
                 membershipDetails: Option[SalesforceSubscription] = None,
                 subscriptionDetails: Option[SalesforceSubscription] = None,
-                newsletterSubscriptions: List[String] = Nil,
+                newslettersSubscription: Option[NewslettersSubscription] = None,
                 hasCommented: Boolean = false,
                 deleted: Boolean = false,
                 orphan: Boolean = false

--- a/test/controllers/UsersControllerTest.scala
+++ b/test/controllers/UsersControllerTest.scala
@@ -25,7 +25,7 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
   val dapiWsMockurl = s"/profile/10000001/stats"
   val dapiWsMock = MockWS { case (GET, dapiWsMockurl) => Action {Ok("""{"status":"ok","comments":0,"pickedComments":0}""")}}
   val exactTargetServiceMock = mock[ExactTargetService]
-  when(exactTargetServiceMock.newsletterSubscriptions("abc")).thenReturn(Future.successful(Nil))
+  when(exactTargetServiceMock.newslettersSubscription("abc")).thenReturn(Future.successful(None))
 
   class StubAuthenticatedAction extends AuthenticatedAction {
     val secret = "secret"


### PR DESCRIPTION
Status of email address in ExactTarget. 

https://github.com/salesforce-marketingcloud/FuelSDK-Java/blob/61500fe211e99e9654babee98c22897d85d106ef/src/main/java/com/exacttarget/fuelsdk/ETSubscriber.java#L182

        ACTIVE("Active"),
        BOUNCED("Bounced"),
        DELETED("Deleted"),
        HELD("Held"),
        UNSUBSCRIBED("Unsubscribed");