### PR TITLE
Standardise response type accros services

### DIFF
--- a/app/controllers/ReservedUsernameController.scala
+++ b/app/controllers/ReservedUsernameController.scala
@@ -9,6 +9,8 @@ import play.api.libs.json.{JsError, JsSuccess, Json}
 import play.api.mvc.Controller
 import repositories.ReservedUserNameWriteRepository
 
+import scalaz.{-\/, \/-}
+
 case class ReservedUsernameRequest(username: String)
 
 object ReservedUsernameRequest {
@@ -23,8 +25,8 @@ class ReservedUsernameController @Inject() (reservedUsernameRepository: Reserved
       case JsSuccess(result, path) =>
         logger.info(s"Reserving username: ${result.username}")
         reservedUsernameRepository.addReservedUsername(result.username) match {
-          case Left(error) => InternalServerError(error)
-          case Right(success) => NoContent
+          case -\/(error) => InternalServerError(error)
+          case \/-(success) => NoContent
         }
       case JsError(e) => BadRequest(ApiError("Failed to reserve username", e.toString))
     }
@@ -32,8 +34,8 @@ class ReservedUsernameController @Inject() (reservedUsernameRepository: Reserved
 
   def getReservedUsernames = auth { request =>
     reservedUsernameRepository.loadReservedUsernames match {
-      case Left(error) => InternalServerError(error)
-      case Right(success) => Ok(Json.toJson(success))
+      case -\/(error) => InternalServerError(error)
+      case \/-(success) => Ok(Json.toJson(success))
     }
   }
 
@@ -42,8 +44,8 @@ class ReservedUsernameController @Inject() (reservedUsernameRepository: Reserved
       case JsSuccess(result, path) =>
         logger.info(s"Unreserving username: ${result.username}")
         reservedUsernameRepository.removeReservedUsername(result.username) match {
-          case Left(error) => InternalServerError(error)
-          case Right(success) => NoContent
+          case -\/(error) => InternalServerError(error)
+          case \/-(success) => NoContent
         }
       case JsError(error) => BadRequest(ApiError("Failed to unreserve username", error.toString))
     }

--- a/app/controllers/ReservedUsernameController.scala
+++ b/app/controllers/ReservedUsernameController.scala
@@ -1,15 +1,12 @@
 package controllers
 
 import javax.inject.{Inject, Singleton}
-
 import actions.AuthenticatedAction
 import com.gu.identity.util.Logging
 import models._
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import play.api.mvc.Controller
 import repositories.ReservedUserNameWriteRepository
-
-import scalaz.{-\/, \/-}
 
 case class ReservedUsernameRequest(username: String)
 
@@ -24,29 +21,29 @@ class ReservedUsernameController @Inject() (reservedUsernameRepository: Reserved
     request.body.validate[ReservedUsernameRequest] match {
       case JsSuccess(result, path) =>
         logger.info(s"Reserving username: ${result.username}")
-        reservedUsernameRepository.addReservedUsername(result.username) match {
-          case -\/(error) => InternalServerError(error)
-          case \/-(success) => NoContent
-        }
+        reservedUsernameRepository.addReservedUsername(result.username).fold(
+          error => InternalServerError(error),
+          _ => NoContent
+        )
       case JsError(e) => BadRequest(ApiError("Failed to reserve username", e.toString))
     }
   }
 
   def getReservedUsernames = auth { request =>
-    reservedUsernameRepository.loadReservedUsernames match {
-      case -\/(error) => InternalServerError(error)
-      case \/-(success) => Ok(Json.toJson(success))
-    }
+    reservedUsernameRepository.loadReservedUsernames.fold(
+      error => InternalServerError(error),
+      success => Ok(Json.toJson(success))
+    )
   }
 
   def unreserveUsername() = auth(parse.json) { request =>
     request.body.validate[ReservedUsernameRequest] match {
       case JsSuccess(result, path) =>
         logger.info(s"Unreserving username: ${result.username}")
-        reservedUsernameRepository.removeReservedUsername(result.username) match {
-          case -\/(error) => InternalServerError(error)
-          case \/-(success) => NoContent
-        }
+        reservedUsernameRepository.removeReservedUsername(result.username).fold(
+          error => InternalServerError(error),
+          _ => NoContent
+        )
       case JsError(error) => BadRequest(ApiError("Failed to unreserve username", error.toString))
     }
   }

--- a/app/controllers/UsersController.scala
+++ b/app/controllers/UsersController.scala
@@ -110,11 +110,12 @@ class UsersController @Inject() (
         UserUpdateRequestValidator.isValid(result).fold(
           e => Future(BadRequest(ApiError("Failed to update user", e.message))),
           validUserUpdateRequest => {
-            if (Config.stage == "PROD") Tip.verify("User Update")
-            logger.info(s"Updating user id:$id, body: $result")
             EitherT(userService.update(request.user, validUserUpdateRequest)).fold(
               error => InternalServerError(error),
-              user => Ok(Json.toJson(user))
+              user => {
+                if (Config.stage == "PROD") Tip.verify("User Update")
+                Ok(Json.toJson(user))
+              }
             )
           }
         )

--- a/app/models/ApiResponse.scala
+++ b/app/models/ApiResponse.scala
@@ -1,5 +1,6 @@
 import scala.concurrent.Future
+import scalaz.\/
 
 package object models {
-  type ApiResponse[T] = Future[Either[ApiError,T]]
+  type ApiResponse[T] = Future[ApiError \/ T]
 }

--- a/app/models/UserUpdateRequestValidator.scala
+++ b/app/models/UserUpdateRequestValidator.scala
@@ -1,18 +1,20 @@
 package models
 
+import scalaz.{-\/, \/, \/-}
+
 case class ValidationError(message: String)
 
 object UserUpdateRequestValidator {
 
-  def isValid(userUpdateRequest: UserUpdateRequest): Either[ValidationError, UserUpdateRequest] = {
+  def isValid(userUpdateRequest: UserUpdateRequest): ValidationError \/ UserUpdateRequest = {
     val validUsernameAndDisplayName = (userUpdateRequest.username, userUpdateRequest.displayName) match {
       case (Some(newUsername), Some(newDisplayName)) => newUsername == newDisplayName
       case _ => true
     }
     if (validUsernameAndDisplayName) {
-      Right(userUpdateRequest)
+      \/-(userUpdateRequest)
     } else {
-      Left(ValidationError("Conflict between username and display name"))
+      -\/(ValidationError("Conflict between username and display name"))
     }
   }
 

--- a/app/repositories/DeletedUsersRepository.scala
+++ b/app/repositories/DeletedUsersRepository.scala
@@ -3,7 +3,7 @@ package repositories
 import javax.inject.{Inject, Singleton}
 
 import com.gu.identity.util.Logging
-import models.SearchResponse
+import models.{ApiResponse, SearchResponse}
 import play.api.libs.json.{JsObject, Json}
 import play.modules.reactivemongo.ReactiveMongoApi
 import reactivemongo.play.json.collection._
@@ -13,7 +13,7 @@ import reactivemongo.api.ReadPreference
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-import scalaz.OptionT
+import scalaz.{OptionT, \/-}
 import scalaz.std.scalaFuture._
 import DeletedUser._
 import reactivemongo.bson.BSONDocument
@@ -30,10 +30,10 @@ class DeletedUsersRepository @Inject()(reactiveMongoApi: ReactiveMongoApi) exten
        .headOption
     }
 
-  def search(query: String): Future[SearchResponse] =
+  def search(query: String): ApiResponse[SearchResponse] =
     OptionT(findBy(query)).fold(
-      user => SearchResponse.create(1, 0, List(IdentityUser(user.email, _id = Some(user.id)))),
-      SearchResponse.create(0, 0, Nil)
+      user => \/-(SearchResponse.create(1, 0, List(IdentityUser(user.email, _id = Some(user.id))))),
+      \/-(SearchResponse.create(0, 0, Nil))
     )
 
   def insert(id: String, email: String, username: String) =

--- a/app/repositories/ReservedUserNameWriteRepository.scala
+++ b/app/repositories/ReservedUserNameWriteRepository.scala
@@ -1,29 +1,24 @@
 package repositories
 
 import javax.inject.{Inject, Singleton}
-
 import com.gu.identity.util.Logging
 import com.mongodb.casbah.MongoCursor
 import com.mongodb.casbah.commons.MongoDBObject
 import models.{ApiError, ReservedUsernameList}
 import org.bson.types.ObjectId
 import salat.dao.SalatDAO
-
 import scala.util.{Failure, Success, Try}
 import scalaz.{-\/, \/, \/-}
 
 case class ReservedUsername(_id: ObjectId, username: String)
-
 
 @Singleton
 class ReservedUserNameWriteRepository @Inject() (environment: play.api.Environment, salatMongoConnection: SalatMongoConnection)
   extends SalatDAO[ReservedUsername, ObjectId](collection=salatMongoConnection.db()("reservedUsernames")) with Logging {
 
   private def findReservedUsername(username: String): ApiError \/ ReservedUsername =
-    Try {
-      findOne(MongoDBObject("username" -> username))
-    } match {
-      case Success(Some(r)) => \/-(r)
+    Try(findOne(MongoDBObject("username" -> username))) match {
+      case Success(Some(reservedUsername)) => \/-(reservedUsername)
       case Success(None) => -\/(ApiError("Username not found"))
       case Failure(error) =>
         val title = s"Failed to find reserved username $username"
@@ -32,44 +27,37 @@ class ReservedUserNameWriteRepository @Inject() (environment: play.api.Environme
     }
 
   def removeReservedUsername(username: String): ApiError \/ ReservedUsernameList =
-      findReservedUsername(username) match {
-        case \/-(r) => Try {
-          remove(r)
-        } match {
-          case Success(success) => loadReservedUsernames
-          case Failure(t) =>
-            val title = s"Failed to remove reserved username $username"
-            logger.error(title, t)
-            -\/(ApiError(title, t.getMessage))
-        }
-        case -\/(l) => -\/(l)
-      }
+      findReservedUsername(username).fold(
+        error => -\/(error),
+        reservedUsername =>
+          Try(remove(reservedUsername)) match {
+            case Success(success) => loadReservedUsernames
+            case Failure(error) =>
+              val title = s"Failed to remove reserved username $username"
+              logger.error(title, error)
+              -\/(ApiError(title, error.getMessage))
+          }
+      )
 
   def loadReservedUsernames: ApiError \/ ReservedUsernameList =
-    Try {
-      cursorToReservedUsernameList(collection.find().sort(MongoDBObject("username" -> 1)))
-    } match {
-      case Success(r) => \/-(r)
-      case Failure(t) =>
+    Try(cursorToReservedUsernameList(collection.find().sort(MongoDBObject("username" -> 1)))) match {
+      case Success(reservedUsernameList) => \/-(reservedUsernameList)
+      case Failure(error) =>
         val title = "Failed to load reserved usernames"
-        logger.error(title, t)
-        -\/(ApiError(title, t.getMessage))
+        logger.error(title, error)
+        -\/(ApiError(title, error.getMessage))
     }
 
   private def cursorToReservedUsernameList(col: MongoCursor): ReservedUsernameList = ReservedUsernameList(col.map(dbObject => dbObject.get("username").asInstanceOf[String]).toList)
 
-  def addReservedUsername(reservedUsername: String): ApiError \/ ReservedUsernameList = {
-    Try {
-      insert(ReservedUsername(new ObjectId(), reservedUsername))
-    } match {
-      case Success(r) =>
+  def addReservedUsername(reservedUsername: String): ApiError \/ ReservedUsernameList =
+    Try(insert(ReservedUsername(new ObjectId(), reservedUsername))) match {
+      case Success(_) =>
         logger.info(s"Reserving username: $reservedUsername")
         loadReservedUsernames
-      case Failure(t) =>
+      case Failure(error) =>
         val title = s"Failed to add $reservedUsername to reserved username list"
-        logger.error(title, t)
-        -\/(ApiError(title, t.getMessage))
+        logger.error(title, error)
+        -\/(ApiError(title, error.getMessage))
     }
-  }
-
 }

--- a/app/repositories/UsersReadRepository.scala
+++ b/app/repositories/UsersReadRepository.scala
@@ -3,7 +3,7 @@ package repositories
 import javax.inject.{Inject, Singleton}
 
 import com.gu.identity.util.Logging
-import models.{SearchResponse, User}
+import models.{ApiResponse, SearchResponse, User}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
 import play.modules.reactivemongo.ReactiveMongoApi
@@ -12,6 +12,7 @@ import reactivemongo.play.json._
 import reactivemongo.api.{Cursor, QueryOpts, ReadPreference}
 
 import scala.concurrent.Future
+import scalaz.\/-
 
 
 @Singleton
@@ -20,7 +21,7 @@ class UsersReadRepository @Inject() (reactiveMongoApi: ReactiveMongoApi) extends
   private val MaximumResults = 20
   private lazy val usersCollectionF = reactiveMongoApi.database.map(_.collection("users"))
 
-  def search(query: String, limit: Option[Int] = None, offset: Option[Int] = None): Future[SearchResponse] =  {
+  def search(query: String, limit: Option[Int] = None, offset: Option[Int] = None): ApiResponse[SearchResponse] =  {
     usersCollectionF.flatMap { usersCollection =>
       val q = buildSearchQuery(query)
       val total = usersCollection.count(Some(q))
@@ -38,7 +39,7 @@ class UsersReadRepository @Inject() (reactiveMongoApi: ReactiveMongoApi) extends
         t <- total
         r <- results
       } yield {
-        SearchResponse.create(t, o, r)
+        \/-(SearchResponse.create(t, o, r))
       }
     }
   }

--- a/app/services/DiscussionService.scala
+++ b/app/services/DiscussionService.scala
@@ -4,6 +4,7 @@ import javax.inject.{Inject, Singleton}
 import com.gu.identity.util.Logging
 import configuration.Config
 import models.{ApiError, ApiResponse}
+import play.api.http.Status
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -18,10 +19,18 @@ object DiscussionStats {
 @Singleton class DiscussionService @Inject() (ws: WSClient) extends Logging {
   def hasCommented(id: String): ApiResponse[Boolean] = {
     ws.url(s"${Config.Discussion.apiUrl}/profile/$id/stats").get().map { response =>
-      Json.parse(response.body).validate[DiscussionStats].fold(
-        error => -\/(ApiError("Failed to determine if user has commented due to Json parsing error", error.toString)),
-        discussionStats => \/-(discussionStats.comments > 0)
-      )
+      if (response.status == Status.NOT_FOUND) {
+        \/-(false)
+      } else {
+        Json.parse(response.body).validate[DiscussionStats].fold(
+          error =>  {
+            logger.error(response.body)
+            -\/(ApiError("Failed to determine if user has commented due to Json parsing error", error.toString))
+
+          },
+          discussionStats => \/-(discussionStats.comments > 0)
+        )
+      }
     }.recover { case error => -\/(ApiError("Failed to communicate with DAPI", error.getMessage)) }
   }
 }

--- a/app/services/DiscussionService.scala
+++ b/app/services/DiscussionService.scala
@@ -1,14 +1,13 @@
 package services
 
 import javax.inject.{Inject, Singleton}
-
 import com.gu.identity.util.Logging
 import configuration.Config
+import models.{ApiError, ApiResponse}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
-
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import scala.concurrent.Future
+import scalaz.{-\/, \/-}
 
 case class DiscussionStats(status: String, comments: Int, pickedComments: Int)
 
@@ -17,12 +16,13 @@ object DiscussionStats {
 }
 
 @Singleton class DiscussionService @Inject() (ws: WSClient) extends Logging {
-
-  def hasCommented(id: String): Future[Boolean] = {
+  def hasCommented(id: String): ApiResponse[Boolean] = {
     ws.url(s"${Config.Discussion.apiUrl}/profile/$id/stats").get().map { response =>
-      val stats = Json.parse(response.body).as[DiscussionStats]
-      stats.comments > 0
-    }.recover { case _ => false }
+      Json.parse(response.body).validate[DiscussionStats].fold(
+        error => -\/(ApiError("Failed to determine if user has commented due to Json parsing error", error.toString)),
+        discussionStats => \/-(discussionStats.comments > 0)
+      )
+    }.recover { case error => -\/(ApiError("Failed to communicate with DAPI", error.getMessage)) }
   }
 }
 

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -5,11 +5,11 @@ import javax.inject.{Inject, Singleton}
 import com.exacttarget.fuelsdk._
 import com.gu.identity.util.Logging
 import configuration.Config
-import models.{ApiError, NewslettersSubscription}
+import models.{ApiError, ApiResponse, NewslettersSubscription}
 
 import scala.concurrent.Future
 import scalaz.std.scalaFuture._
-import scalaz.{OptionT, \/}
+import scalaz.{-\/, OptionT, \/, \/-}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import repositories.UsersReadRepository
 
@@ -73,19 +73,18 @@ class ExactTargetService @Inject() (usersReadRepository: UsersReadRepository) ex
     }
   }
 
-  def newslettersSubscription(identityId: String): Future[Option[NewslettersSubscription]] =
+  def newslettersSubscription(identityId: String): ApiResponse[Option[NewslettersSubscription]] =
     OptionT(usersReadRepository.findById(identityId)).fold(
       user => {
         val response = etClientEditorial.retrieve(classOf[ETSubscriber], s"key=${user.email}")
-        Option(response.getResult).fold[Option[NewslettersSubscription]]
-          { None }
-          { result =>
-              Some(NewslettersSubscription(
-                status = result.getObject.getStatus.value(),
-                list = result.getObject.getSubscriptions.toList.filter(_.getStatus == ETSubscriber.Status.ACTIVE).map(_.getListId)))
+        Option(response.getResult).fold[ApiError \/ Option[NewslettersSubscription]]
+          { -\/(ApiError("Failed to retrieve subscriber from ExactTarget")) }
+          { result => \/-(Some(NewslettersSubscription(
+              status = result.getObject.getStatus.value(),
+              list = result.getObject.getSubscriptions.toList.filter(_.getStatus == ETSubscriber.Status.ACTIVE).map(_.getListId))))
           }
       },
-      None
+      \/-(None)
     )
 
   private lazy val etClientAdmin = {

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -1,18 +1,15 @@
 package services
 
 import javax.inject.{Inject, Singleton}
-
 import com.exacttarget.fuelsdk._
 import com.gu.identity.util.Logging
 import configuration.Config
 import models.{ApiError, ApiResponse, NewslettersSubscription}
-
 import scala.concurrent.Future
 import scalaz.std.scalaFuture._
 import scalaz.{-\/, OptionT, \/, \/-}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import repositories.UsersReadRepository
-
 import scala.collection.JavaConversions._
 
 @Singleton
@@ -77,8 +74,8 @@ class ExactTargetService @Inject() (usersReadRepository: UsersReadRepository) ex
     OptionT(usersReadRepository.findById(identityId)).fold(
       user => {
         val response = etClientEditorial.retrieve(classOf[ETSubscriber], s"key=${user.email}")
-        Option(response.getResult).fold[ApiError \/ Option[NewslettersSubscription]]
-          { -\/(ApiError("Failed to retrieve subscriber from ExactTarget")) }
+        Option(response.getResult).fold
+          { \/-[Option[NewslettersSubscription]](None) }
           { result => \/-(Some(NewslettersSubscription(
               status = result.getObject.getStatus.value(),
               list = result.getObject.getSubscriptions.toList.filter(_.getStatus == ETSubscriber.Status.ACTIVE).map(_.getListId))))

--- a/conf/DEV.conf
+++ b/conf/DEV.conf
@@ -22,6 +22,6 @@ events {
   enabled = false
 }
 
-discussion.api.url = "https://discussion.thegulocal.com"
+discussion.api.url = "https://discussion.code.dev-theguardian.com/discussion-api"
 
 madgex.api.url="https://guardianjobs-web.madgexjbtest.com"

--- a/test/controllers/ReservedUsernameControllerTest.scala
+++ b/test/controllers/ReservedUsernameControllerTest.scala
@@ -12,6 +12,7 @@ import repositories.ReservedUserNameWriteRepository
 import org.mockito.Mockito._
 
 import scala.concurrent.Future
+import scalaz.{-\/, \/-}
 
 class ReservedUsernameControllerTest extends WordSpec with Matchers with MockitoSugar {
 
@@ -35,7 +36,7 @@ class ReservedUsernameControllerTest extends WordSpec with Matchers with Mockito
 
     "return no content when succesful" in {
       val json = """{"username":"usernameToReserve"}"""
-      when(reservedUsernameRepo.addReservedUsername("usernameToReserve")).thenReturn(Right(ReservedUsernameList()))
+      when(reservedUsernameRepo.addReservedUsername("usernameToReserve")).thenReturn(\/-(ReservedUsernameList()))
       val result = controller.reserveUsername()(FakeRequest().withBody(Json.parse(json)))
       status(result) shouldEqual NO_CONTENT
     }
@@ -43,7 +44,7 @@ class ReservedUsernameControllerTest extends WordSpec with Matchers with Mockito
     "return internal server error when error occurs" in {
       val json = """{"username":"usernameToReserve"}"""
       val error = ApiError("boom")
-      when(reservedUsernameRepo.addReservedUsername("usernameToReserve")).thenReturn(Left(error))
+      when(reservedUsernameRepo.addReservedUsername("usernameToReserve")).thenReturn(-\/(error))
       val result = controller.reserveUsername()(FakeRequest().withBody(Json.parse(json)))
       status(result) shouldEqual INTERNAL_SERVER_ERROR
       contentAsJson(result) shouldEqual Json.toJson(error)
@@ -59,7 +60,7 @@ class ReservedUsernameControllerTest extends WordSpec with Matchers with Mockito
 
     "return no content when succesful" in {
       val json = """{"username":"usernameToReserve"}"""
-      when(reservedUsernameRepo.removeReservedUsername("usernameToReserve")).thenReturn(Right(ReservedUsernameList()))
+      when(reservedUsernameRepo.removeReservedUsername("usernameToReserve")).thenReturn(\/-(ReservedUsernameList()))
       val result = controller.unreserveUsername()(FakeRequest().withBody(Json.parse(json)))
       status(result) shouldEqual NO_CONTENT
     }
@@ -67,7 +68,7 @@ class ReservedUsernameControllerTest extends WordSpec with Matchers with Mockito
     "return internal server error when error occurs" in {
       val json = """{"username":"usernameToReserve"}"""
       val error = ApiError("boom")
-      when(reservedUsernameRepo.removeReservedUsername("usernameToReserve")).thenReturn(Left(error))
+      when(reservedUsernameRepo.removeReservedUsername("usernameToReserve")).thenReturn(-\/(error))
       val result = controller.unreserveUsername()(FakeRequest().withBody(Json.parse(json)))
       status(result) shouldEqual INTERNAL_SERVER_ERROR
       contentAsJson(result) shouldEqual Json.toJson(error)
@@ -77,7 +78,7 @@ class ReservedUsernameControllerTest extends WordSpec with Matchers with Mockito
   "getReservedUsernames" should {
     "return reserved usernames when successful" in {
       val reservedUsernameList = ReservedUsernameList(List("1", "2", "3"))
-      when(reservedUsernameRepo.loadReservedUsernames).thenReturn(Right(reservedUsernameList))
+      when(reservedUsernameRepo.loadReservedUsernames).thenReturn(\/-(reservedUsernameList))
       val result = controller.getReservedUsernames(FakeRequest())
       status(result) shouldEqual OK
       contentAsJson(result) shouldEqual Json.toJson(reservedUsernameList)
@@ -85,7 +86,7 @@ class ReservedUsernameControllerTest extends WordSpec with Matchers with Mockito
 
     "return internal server error when error occurs" in {
       val error = ApiError("boom")
-      when(reservedUsernameRepo.loadReservedUsernames).thenReturn(Left(error))
+      when(reservedUsernameRepo.loadReservedUsernames).thenReturn(-\/(error))
       val result = controller.getReservedUsernames(FakeRequest())
       status(result) shouldEqual INTERNAL_SERVER_ERROR
       contentAsJson(result) shouldEqual Json.toJson(error)

--- a/test/controllers/UsersControllerTest.scala
+++ b/test/controllers/UsersControllerTest.scala
@@ -26,7 +26,7 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
   val dapiWsMockurl = s"/profile/10000001/stats"
   val dapiWsMock = MockWS { case (GET, dapiWsMockurl) => Action {Ok("""{"status":"ok","comments":0,"pickedComments":0}""")}}
   val exactTargetServiceMock = mock[ExactTargetService]
-  when(exactTargetServiceMock.newslettersSubscription("abc")).thenReturn(Future.successful(None))
+  when(exactTargetServiceMock.newslettersSubscription("abc")).thenReturn(Future.successful(\/-(None)))
 
   class StubAuthenticatedAction extends AuthenticatedAction {
     val secret = "secret"
@@ -36,13 +36,13 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
   }
 
   class StubSalesfroce extends SalesforceService {
-    override def getSubscriptionByIdentityId(id: String): Future[Option[SalesforceSubscription]] = Future(None)
-    override def getSubscriptionByEmail(email: String): Future[Option[SalesforceSubscription]] = Future(None)
-    override def getSubscriptionBySubscriptionId(subscriptionId: String): Future[Option[SalesforceSubscription]] = Future(None)
-    override def getMembershipByIdentityId(id: String): Future[Option[SalesforceSubscription]] = Future(None)
-    override def getMembershipByMembershipNumber(membershipNumber: String): Future[Option[SalesforceSubscription]] = Future(None)
-    override def getMembershipByEmail(email: String): Future[Option[SalesforceSubscription]] = Future(None)
-    override def getMembershipBySubscriptionId(subscriptionId: String): Future[Option[SalesforceSubscription]] = Future(None)
+    override def getSubscriptionByIdentityId(id: String): ApiResponse[Option[SalesforceSubscription]] = Future(\/-(None))
+    override def getSubscriptionByEmail(email: String): ApiResponse[Option[SalesforceSubscription]] = Future(\/-(None))
+    override def getSubscriptionBySubscriptionId(subscriptionId: String): ApiResponse[Option[SalesforceSubscription]] = Future(\/-(None))
+    override def getMembershipByIdentityId(id: String): ApiResponse[Option[SalesforceSubscription]] = Future(\/-(None))
+    override def getMembershipByMembershipNumber(membershipNumber: String): ApiResponse[Option[SalesforceSubscription]] = Future(\/-(None))
+    override def getMembershipByEmail(email: String): ApiResponse[Option[SalesforceSubscription]] = Future(\/-(None))
+    override def getMembershipBySubscriptionId(subscriptionId: String): ApiResponse[Option[SalesforceSubscription]] = Future(\/-(None))
   }
 
   val controller = new UsersController(

--- a/test/repositories/ReservedUsernameRepositoryTest.scala
+++ b/test/repositories/ReservedUsernameRepositoryTest.scala
@@ -7,6 +7,8 @@ import org.scalatest.DoNotDiscover
 import org.scalatestplus.play.{OneServerPerSuite, PlaySpec}
 import play.api.Play
 
+import scalaz.-\/
+
 
 @DoNotDiscover
 class ReservedUsernameRepositoryTest extends PlaySpec with OneServerPerSuite {
@@ -18,7 +20,7 @@ class ReservedUsernameRepositoryTest extends PlaySpec with OneServerPerSuite {
 
       val result = repo.addReservedUsername(username)
       result.isRight mustBe true
-      result.right.get.reservedUsernames must contain(username)
+      result.map(_.reservedUsernames must contain(username))
     }
   }
 
@@ -31,7 +33,7 @@ class ReservedUsernameRepositoryTest extends PlaySpec with OneServerPerSuite {
 
       val result = repo.removeReservedUsername(username)
       result.isRight mustBe true
-      result.right.get.reservedUsernames must not contain(username)
+      result.map(_.reservedUsernames must not contain(username))
     }
 
     "return not found if the username doesn't exist" in {
@@ -39,7 +41,7 @@ class ReservedUsernameRepositoryTest extends PlaySpec with OneServerPerSuite {
       val username = UUID.randomUUID().toString
 
       val result = repo.removeReservedUsername(username)
-      result mustEqual Left(ApiError("User not found"))
+      result mustEqual -\/(ApiError("User not found"))
     }
   }
 }

--- a/test/repositories/UsersRepositoryTest.scala
+++ b/test/repositories/UsersRepositoryTest.scala
@@ -41,7 +41,7 @@ class UsersRepositoryTest @Inject() (app: Application) extends PlaySpec with One
         val writeRepo = app.injector.instanceOf(classOf[UsersWriteRepository])
         val user = createUser()
         val createdUser = writeRepo.createUser(user)
-        Await.result(repo.search(user.primaryEmailAddress), 1.second).results.map(_.id) must contain(createdUser.get)
+        Await.result(repo.search(user.primaryEmailAddress), 1.second).fold(_ => fail, _.results.map(_.id) must contain(createdUser.get))
       }
 
       "return a user when username matches exactly" in {
@@ -50,7 +50,7 @@ class UsersRepositoryTest @Inject() (app: Application) extends PlaySpec with One
         val username = UUID.randomUUID().toString
         val user = createUser(username = Some(username))
         val createdUser = writeRepo.createUser(user)
-        Await.result(repo.search(username), 1.second).results.map(_.id) must contain(createdUser.get)
+        Await.result(repo.search(username), 1.second).fold(_ => fail, _.results.map(_.id) must contain(createdUser.get))
       }
 
       "return a user when postcode matches exactly" in {
@@ -59,7 +59,7 @@ class UsersRepositoryTest @Inject() (app: Application) extends PlaySpec with One
         val postcode = "N1 9GU"
         val user = createUser(postcode = Some(postcode))
         val createdUser = writeRepo.createUser(user)
-        Await.result(repo.search(postcode), 1.second).results.map(_.id) must contain(createdUser.get)
+        Await.result(repo.search(postcode), 1.second).fold(_ => fail, _.results.map(_.id) must contain(createdUser.get))
       }
 
       "return a user when postcode prefix matches" in {
@@ -68,7 +68,7 @@ class UsersRepositoryTest @Inject() (app: Application) extends PlaySpec with One
         val postcode = "N1 9GU"
         val user = createUser(postcode = Some(postcode))
         val createdUser = writeRepo.createUser(user)
-        Await.result(repo.search("N1"), 1.second).results.map(_.id) must contain(createdUser.get)
+        Await.result(repo.search("N1"), 1.second).fold(_ => fail, _.results.map(_.id) must contain(createdUser.get))
       }
 
       "return a user when registered ip matches exactly" in {
@@ -77,7 +77,7 @@ class UsersRepositoryTest @Inject() (app: Application) extends PlaySpec with One
         val ip = "127.0.0.1"
         val user = createUser(registeredIp = Some(ip))
         val createdUser = writeRepo.createUser(user)
-        Await.result(repo.search(ip), 1.second).results.map(_.id) must contain(createdUser.get)
+        Await.result(repo.search(ip), 1.second).fold(_ => fail, _.results.map(_.id) must contain(createdUser.get))
       }
 
       "return a user when last active ip matches exactly" in {
@@ -86,7 +86,7 @@ class UsersRepositoryTest @Inject() (app: Application) extends PlaySpec with One
         val ip = "127.0.0.1"
         val user = createUser(lastActiveIp = Some(ip))
         val createdUser = writeRepo.createUser(user)
-        Await.result(repo.search(ip), 1.second).results.map(_.id) must contain(createdUser.get)
+        Await.result(repo.search(ip), 1.second).fold(_ => fail, _.results.map(_.id) must contain(createdUser.get))
       }
       
       "return Nil when no results are found" in {
@@ -110,12 +110,17 @@ class UsersRepositoryTest @Inject() (app: Application) extends PlaySpec with One
         val createdUser4 = writeRepo.createUser(user4)
         val createdUser5 = writeRepo.createUser(user5)
 
-        val ids = Await.result(repo.search(postcode, offset = Some(1)), 1.second).results.map(_.id)
-        ids must not contain createdUser1.get
-        ids must contain(createdUser2.get)
-        ids must contain(createdUser3.get)
-        ids must contain(createdUser4.get)
-        ids must contain(createdUser5.get)
+        val ids = Await.result(repo.search(postcode, offset = Some(1)), 1.second).fold(
+          _ => fail,
+          searchResponse => {
+            val ids = searchResponse.results.map(_.id)
+            ids must not contain createdUser1.get
+            ids must contain(createdUser2.get)
+            ids must contain(createdUser3.get)
+            ids must contain(createdUser4.get)
+            ids must contain(createdUser5.get)
+          }
+        )
       }
 
       "use limit when provided" in {
@@ -134,12 +139,16 @@ class UsersRepositoryTest @Inject() (app: Application) extends PlaySpec with One
         val createdUser4 = writeRepo.createUser(user4)
         val createdUser5 = writeRepo.createUser(user5)
 
-        val ids = Await.result(repo.search(postcode, offset = Some(1), limit = Some(2)), 1.second).results.map(_.id)
-        ids.size mustEqual 2
-        ids must contain(createdUser2.get)
-        ids must contain(createdUser3.get)
+        val ids = Await.result(repo.search(postcode, offset = Some(1), limit = Some(2)), 1.second).fold(
+          _ => fail,
+          searchResponse => {
+            val ids = searchResponse.results.map(_.id)
+            ids.size mustEqual 2
+            ids must contain(createdUser2.get)
+            ids must contain(createdUser3.get)
+          }
+        )
       }
-
   }
 
   "findById" should {

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -12,6 +12,7 @@ import scala.concurrent.{Await, Future}
 import org.mockito.Mockito._
 
 import scala.concurrent.duration._
+import scalaz.{-\/, \/-}
 
 class UserServiceTest extends WordSpec with MockitoSugar with Matchers with BeforeAndAfter {
 
@@ -109,12 +110,12 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updatedUser = user.copy(email = updateRequest.email)
 
       when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
-      when(userWriteRepo.update(user, updateRequest)).thenReturn(Right(updatedUser))
-      when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(Right(true)))
+      when(userWriteRepo.update(user, updateRequest)).thenReturn(\/-(updatedUser))
+      when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(\/-(true)))
 
       val result = service.update(user, userUpdateRequest)
 
-      Await.result(result, 1.second) shouldEqual Right(updatedUser)
+      Await.result(result, 1.second) shouldEqual \/-(updatedUser)
       verify(identityApiClient).sendEmailValidation(user.id)
     }
 
@@ -126,12 +127,12 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updatedUser = user.copy(email = updateRequest.email)
 
       when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
-      when(userWriteRepo.update(user, updateRequest)).thenReturn(Right(updatedUser))
-      when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(Right(true)))
+      when(userWriteRepo.update(user, updateRequest)).thenReturn(\/-(updatedUser))
+      when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(\/-(true)))
 
       val result = service.update(user, userUpdateRequest)
 
-      Await.result(result, 1.second) shouldEqual Right(updatedUser)
+      Await.result(result, 1.second) shouldEqual \/-(updatedUser)
       verify(madgexService).update(gNMMadgexUser)
     }
 
@@ -142,9 +143,9 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updatedUser = user.copy(email = updateRequest.email)
 
       when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
-      when(userWriteRepo.update(user, updateRequest)).thenReturn(Right(updatedUser))
+      when(userWriteRepo.update(user, updateRequest)).thenReturn(\/-(updatedUser))
 
-      Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual Right(updatedUser)
+      Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual \/-(updatedUser)
       verifyZeroInteractions(madgexService)
     }
 
@@ -155,9 +156,9 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updatedUser = user.copy(email = updateRequest.email)
 
       when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
-      when(userWriteRepo.update(user, updateRequest)).thenReturn(Right(updatedUser))
+      when(userWriteRepo.update(user, updateRequest)).thenReturn(\/-(updatedUser))
 
-      Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual Right(updatedUser)
+      Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual \/-(updatedUser)
       verifyZeroInteractions(identityApiClient)
     }
 
@@ -169,11 +170,11 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updatedUser = user.copy(email = updateRequest.email)
 
       when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
-      when(userWriteRepo.update(user, updateRequest)).thenReturn(Right(updatedUser))
+      when(userWriteRepo.update(user, updateRequest)).thenReturn(\/-(updatedUser))
 
       val result = service.update(user, userUpdateRequest)
 
-      Await.result(result, 1.second) shouldEqual Right(updatedUser)
+      Await.result(result, 1.second) shouldEqual \/-(updatedUser)
       verifyZeroInteractions(madgexService)
     }
 
@@ -181,7 +182,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val user = User("id", "email@theguardian.com")
       val updateRequest = UserUpdateRequest(email = user.email, username = Some("123"))
 
-      Await.result(service.update(user, updateRequest), 1.second) shouldEqual Left(ApiError("Username is invalid"))
+      Await.result(service.update(user, updateRequest), 1.second) shouldEqual -\/(ApiError("Username is invalid"))
       verifyZeroInteractions(userReadRepo, userWriteRepo)
     }
 
@@ -189,7 +190,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val user = User("id", "email@theguardian.com")
       val updateRequest = UserUpdateRequest(email = user.email, username = Some("123456789012345678901"))
 
-      Await.result(service.update(user, updateRequest), 1.second) shouldEqual Left(ApiError("Username is invalid"))
+      Await.result(service.update(user, updateRequest), 1.second) shouldEqual -\/(ApiError("Username is invalid"))
       verifyZeroInteractions(userReadRepo, userWriteRepo)
     }
 
@@ -197,7 +198,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val user = User("id", "email@theguardian.com")
       val updateRequest = UserUpdateRequest(email = user.email, username = Some("abc123$"))
 
-      Await.result(service.update(user, updateRequest), 1.second) shouldEqual Left(ApiError("Username is invalid"))
+      Await.result(service.update(user, updateRequest), 1.second) shouldEqual -\/(ApiError("Username is invalid"))
       verifyZeroInteractions(userReadRepo, userWriteRepo)
     }
 
@@ -207,7 +208,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
 
       when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(Some(user)))
 
-      Await.result(service.update(user, updateRequest), 1.second) shouldEqual Left(ApiError("Email is invalid"))
+      Await.result(service.update(user, updateRequest), 1.second) shouldEqual -\/(ApiError("Email is invalid"))
       verifyZeroInteractions(userWriteRepo)
     }
 
@@ -219,7 +220,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
 
       val result = service.update(user, updateRequest)
 
-      Await.result(result, 1.second) shouldEqual Left(ApiError("Email and username are invalid"))
+      Await.result(result, 1.second) shouldEqual -\/(ApiError("Email and username are invalid"))
       verifyZeroInteractions(userWriteRepo)
     }
 
@@ -229,9 +230,9 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updateRequest = IdentityUserUpdate(userUpdateRequest, None)
 
       when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
-      when(userWriteRepo.update(user, updateRequest)).thenReturn(Left(ApiError("boom")))
+      when(userWriteRepo.update(user, updateRequest)).thenReturn(-\/(ApiError("boom")))
 
-      Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual Left(ApiError("boom"))
+      Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual -\/(ApiError("boom"))
       verify(identityApiClient, never()).sendEmailValidation(user.id)
     }
   }
@@ -240,62 +241,62 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
     "remove the given user and reserve username" in {
       val username = "testuser"
       val user = User("id", "email", username = Some(username))
-      when(userWriteRepo.delete(user)).thenReturn(Right(true))
-      when(reservedUsernameRepo.addReservedUsername(username)).thenReturn(Right(ReservedUsernameList(List(username))))
-      Await.result(service.delete(user), 1.second) shouldEqual Right(ReservedUsernameList(List(username)))
+      when(userWriteRepo.delete(user)).thenReturn(\/-(true))
+      when(reservedUsernameRepo.addReservedUsername(username)).thenReturn(\/-(ReservedUsernameList(List(username))))
+      Await.result(service.delete(user), 1.second) shouldEqual \/-(ReservedUsernameList(List(username)))
     }
 
     "remove the given user and return existing reserved usernames when user has no username" in {
       val user = User("id", "email", username = None)
-      when(userWriteRepo.delete(user)).thenReturn(Right(true))
-      when(reservedUsernameRepo.loadReservedUsernames).thenReturn(Right(ReservedUsernameList(Nil)))
-      Await.result(service.delete(user), 1.second) shouldEqual Right(ReservedUsernameList(Nil))
+      when(userWriteRepo.delete(user)).thenReturn(\/-(true))
+      when(reservedUsernameRepo.loadReservedUsernames).thenReturn(\/-(ReservedUsernameList(Nil)))
+      Await.result(service.delete(user), 1.second) shouldEqual \/-(ReservedUsernameList(Nil))
     }
 
     "return internal server api error if an error occurs deleting the user" in {
       val user = User("id", "email")
-      when(userWriteRepo.delete(user)).thenReturn(Left(ApiError("boom")))
-      Await.result(service.delete(user), 1.second) shouldEqual Left(ApiError("boom"))
+      when(userWriteRepo.delete(user)).thenReturn(-\/(ApiError("boom")))
+      Await.result(service.delete(user), 1.second) shouldEqual -\/(ApiError("boom"))
     }
   }
 
   "validateEmailAddress" should {
     "validate the email address" in {
       val user = User("id", "email")
-      when(userWriteRepo.updateEmailValidationStatus(user, true)).thenReturn(Right(user))
-      Await.result(service.validateEmail(user), 1.second) shouldEqual Right(true)
+      when(userWriteRepo.updateEmailValidationStatus(user, true)).thenReturn(\/-(user))
+      Await.result(service.validateEmail(user), 1.second) shouldEqual \/-(true)
     }
 
     "return internal server api error if an error occurs validating the email address" in {
       val user = User("id", "email")
-      when(userWriteRepo.updateEmailValidationStatus(user, true)).thenReturn(Left(ApiError("boom")))
+      when(userWriteRepo.updateEmailValidationStatus(user, true)).thenReturn(-\/(ApiError("boom")))
 
-      Await.result(service.validateEmail(user), 1.second) shouldEqual Left(ApiError("boom"))
+      Await.result(service.validateEmail(user), 1.second) shouldEqual -\/(ApiError("boom"))
     }
   }
 
   "sendEmailValidation" should {
     "invalidate the email address and send validation request email" in {
       val user = User("id", "email")
-      when(userWriteRepo.updateEmailValidationStatus(user, false)).thenReturn(Right(user))
-      when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(Right(true)))
-      Await.result(service.sendEmailValidation(user), 1.second) shouldEqual Right(true)
+      when(userWriteRepo.updateEmailValidationStatus(user, false)).thenReturn(\/-(user))
+      when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(\/-(true)))
+      Await.result(service.sendEmailValidation(user), 1.second) shouldEqual \/-(true)
     }
 
     "return internal server api error if an error occurs invalidating the email address" in {
       val user = User("id", "email")
-      when(userWriteRepo.updateEmailValidationStatus(user, false)).thenReturn(Left(ApiError("boom")))
+      when(userWriteRepo.updateEmailValidationStatus(user, false)).thenReturn(-\/(ApiError("boom")))
 
-      Await.result(service.sendEmailValidation(user), 1.second) shouldEqual Left(ApiError("boom"))
+      Await.result(service.sendEmailValidation(user), 1.second) shouldEqual -\/(ApiError("boom"))
       verifyZeroInteractions(identityApiClient)
     }
 
     "return internal server api error if an error occurs sending the email" in {
       val user = User("id", "email")
-      when(userWriteRepo.updateEmailValidationStatus(user, false)).thenReturn(Right(user))
-      when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(Left(ApiError("boom"))))
+      when(userWriteRepo.updateEmailValidationStatus(user, false)).thenReturn(\/-(user))
+      when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(-\/(ApiError("boom"))))
 
-      Await.result(service.sendEmailValidation(user), 1.second) shouldEqual Left(ApiError("boom"))
+      Await.result(service.sendEmailValidation(user), 1.second) shouldEqual -\/(ApiError("boom"))
     }
   }
 


### PR DESCRIPTION
Switch to right biased Either and standardise the response type to `ApiResponse[T]` across different services:
```
type ApiResponse[T] = Future[ApiError \/ T]
```
The reason for this is clear if we look at the diff of the following for-yield:

https://github.com/guardian/identity-admin-api/compare/standardise-response-type-accross-services?expand=1#diff-4406354643a46d6112ae62cc086bf796L55

We can see that previously we were just ignoring the errors from Salesforce, DAPI or ExactTarget, but now these errors are communicated to clients of the API.

Note that this PR does not yet achieve 100% response standardisation, but it is a step towards it. 