### PR TITLE
Use ApiResponse when searching mongo

### DIFF
--- a/app/repositories/DeletedUsersRepository.scala
+++ b/app/repositories/DeletedUsersRepository.scala
@@ -1,16 +1,19 @@
 package repositories
 
 import javax.inject.{Inject, Singleton}
+
 import com.gu.identity.util.Logging
-import models.{ApiResponse, SearchResponse}
+import models.{ApiError, ApiResponse, SearchResponse}
 import play.api.libs.json.Json
 import play.modules.reactivemongo.ReactiveMongoApi
 import reactivemongo.play.json.collection._
 import reactivemongo.play.json._
 import reactivemongo.api.ReadPreference
+
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import scalaz.{OptionT, \/-}
+
+import scalaz.{-\/, EitherT, OptionT, \/-}
 import scalaz.std.scalaFuture._
 import DeletedUser._
 import reactivemongo.bson.BSONDocument
@@ -19,18 +22,24 @@ import reactivemongo.bson.BSONDocument
 
   private lazy val reservedEmailsF = reactiveMongoApi.database.map(_.collection("reservedEmails"))
 
-  def findBy(query: String): Future[Option[DeletedUser]] =
+  def findBy(query: String): ApiResponse[Option[DeletedUser]] =
     reservedEmailsF.flatMap {
       _.find(buildSearchQuery(query))
        .cursor[DeletedUser](ReadPreference.primaryPreferred)
-       .headOption
+       .headOption.map(\/-(_))
+    }.recover { case error =>
+      val title = s"Failed to perform search in MongoDB"
+      logger.error(title, error)
+      -\/(ApiError(title, error.getMessage))
     }
 
   def search(query: String): ApiResponse[SearchResponse] =
-    OptionT(findBy(query)).fold(
-      user => \/-(SearchResponse.create(1, 0, List(IdentityUser(user.email, user.id)))),
-      \/-(SearchResponse.create(0, 0, Nil))
-    )
+    (EitherT(findBy(query)).map { userOpt =>
+      userOpt match {
+        case Some(user) => SearchResponse.create(1, 0, List(IdentityUser(user.email, user.id)))
+        case None => SearchResponse.create(0, 0, Nil)
+      }
+    }).run
 
   def insert(id: String, email: String, username: String) =
     reservedEmailsF.flatMap(_.insert[DeletedUser](DeletedUser(id, email, username)))

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -9,7 +9,7 @@ import models.{ApiError, ApiResponse, NewslettersSubscription}
 
 import scala.concurrent.Future
 import scalaz.std.scalaFuture._
-import scalaz.{EitherT, OptionT, \/, \/-}
+import scalaz.{-\/, EitherT, \/, \/-}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import repositories.UsersReadRepository
 
@@ -19,7 +19,7 @@ import scala.collection.JavaConversions._
   /**
     * Unsubscribe this subscriber from all current and future subscriber lists.
     */
-  def unsubscribeFromAllLists(email: String): Future[ApiError \/ ETSubscriber] = {
+  def unsubscribeFromAllLists(email: String): ApiResponse[ETSubscriber] = {
     logger.info("Unsubscribe from all email lists")
     updateSubscriptionStatus(email, ETSubscriber.Status.UNSUBSCRIBED)
   }
@@ -28,13 +28,13 @@ import scala.collection.JavaConversions._
     * Allows this subscriber to subscribe to lists in the future. This will only activate the subscriber
     * on the All Subscribers list, and not on any specific lists.
     */
-  def activateEmailSubscription(email: String): Future[ApiError \/ ETSubscriber] = {
+  def activateEmailSubscription(email: String): ApiResponse[ETSubscriber] = {
     logger.info("Activate email subscriptions")
     updateSubscriptionStatus(email, ETSubscriber.Status.ACTIVE)
   }
 
   private def updateSubscriptionStatus(
-      email: String, status: ETSubscriber.Status): Future[ApiError \/ ETSubscriber] = Future {
+      email: String, status: ETSubscriber.Status): ApiResponse[ETSubscriber] = Future {
 
     def updateStatus(subscriber: ETSubscriber) = {
       subscriber.setStatus(status)
@@ -73,10 +73,10 @@ import scala.collection.JavaConversions._
 
   def newslettersSubscriptionByIdentityId(identityId: String): ApiResponse[Option[NewslettersSubscription]] =
     EitherT(usersReadRepository.findById(identityId)).fold(
-      error => Future(\/-(None)),
+      error => Future.successful(-\/(error)),
       userOpt => userOpt match {
         case Some(user) => newslettersSubscriptionByEmail(user.email)
-        case None => Future(\/-(None))
+        case None => Future.successful(\/-(None))
       }
     ).flatMap(identity)
 

--- a/test/controllers/UsersControllerTest.scala
+++ b/test/controllers/UsersControllerTest.scala
@@ -106,14 +106,14 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
 
   "findById" should {
     "return 404 when user not found" in {
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(-\/(ApiError("User not found"))))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(None)))
       val result = controller.findById(testIdentityId)(FakeRequest())
       status(result) shouldEqual NOT_FOUND
     }
 
     "return 200 when user found" in {
       val user = User(testIdentityId, "test@test.com")
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(user)))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(Some(user))))
       when(userService.enrichUserWithProducts(any[User])).thenReturn(Future.successful(\/-(user)))
       val result = controller.findById(testIdentityId)(FakeRequest())
       status(result) shouldEqual OK
@@ -130,7 +130,7 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
 
     "return 404 when user is not found" in {
       val userUpdateRequest = UserUpdateRequest(email = "test@test.com", username = Some("username"))
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(-\/(ApiError("User not found"))))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(None)))
       val result = controller.update(testIdentityId)(FakeRequest().withBody(Json.toJson(userUpdateRequest)))
       status(result) shouldEqual NOT_FOUND
     }
@@ -138,7 +138,7 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
     "return 400 when username and display name differ in request" in {
       val userUpdateRequest = UserUpdateRequest(email = "test@test.com", username = Some("username"), displayName = Some("displayname"))
       val user = User("id", "email")
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(user)))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(Some(user))))
       when(userService.update(user, userUpdateRequest)).thenReturn(Future.successful(\/-(user)))
       val result = controller.update(testIdentityId)(FakeRequest().withBody(Json.toJson(userUpdateRequest)))
       status(result) shouldEqual BAD_REQUEST
@@ -147,7 +147,7 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
     "return 200 with updated user when update is successful" in {
       val userUpdateRequest = UserUpdateRequest(email = "test@test.com", username = Some("username"))
       val user = User("id", "email")
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(user)))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(Some(user))))
       when(userService.enrichUserWithProducts(any[User])).thenReturn(Future.successful(\/-(user)))
       when(userService.update(user, userUpdateRequest)).thenReturn(Future.successful(\/-(user)))
       val result = controller.update(testIdentityId)(FakeRequest().withBody(Json.toJson(userUpdateRequest)))
@@ -158,7 +158,7 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
 
   "delete" should {
     "return 404 when user is not found" in {
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(-\/(ApiError("User not found"))))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(None)))
       val result = controller.delete(testIdentityId)(FakeRequest())
       status(result) shouldEqual NOT_FOUND
     }
@@ -166,14 +166,14 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
   
   "sendEmailValidation" should {
     "return 404 when user is not found" in {
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(-\/(ApiError("User not found"))))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(None)))
       val result = controller.sendEmailValidation(testIdentityId)(FakeRequest())
       status(result) shouldEqual NOT_FOUND
     }
 
     "return 204 when email validation is sent" in {
       val user = User("", "")
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(user)))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(Some(user))))
       when(userService.enrichUserWithProducts(any[User])).thenReturn(Future.successful(\/-(user)))
       when(userService.sendEmailValidation(user)).thenReturn(Future.successful(\/-{}))
       val result = controller.sendEmailValidation(testIdentityId)(FakeRequest())
@@ -182,7 +182,7 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
 
     "return 500 when error occurs" in {
       val user = User("", "")
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(user)))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(Some(user))))
       when(userService.sendEmailValidation(user)).thenReturn(Future.successful(-\/(ApiError("boom"))))
       val result = controller.sendEmailValidation(testIdentityId)(FakeRequest())
       status(result) shouldEqual INTERNAL_SERVER_ERROR
@@ -192,14 +192,14 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
 
   "validateEmail" should {
     "return 404 when user is not found" in {
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(-\/(ApiError("User not found"))))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(None)))
       val result = controller.validateEmail(testIdentityId)(FakeRequest())
       status(result) shouldEqual NOT_FOUND
     }
 
     "return 204 when email is validated" in {
       val user = User("", "")
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(user)))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(Some(user))))
       when(userService.validateEmail(user)).thenReturn(Future.successful(\/-{}))
       val result = controller.validateEmail(testIdentityId)(FakeRequest())
       status(result) shouldEqual NO_CONTENT
@@ -207,7 +207,7 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar {
 
     "return 500 when error occurs" in {
       val user = User("", "")
-      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(user)))
+      when(userService.findById(testIdentityId)).thenReturn(Future.successful(\/-(Some(user))))
       when(userService.validateEmail(user)).thenReturn(Future.successful(-\/(ApiError("boom"))))
       val result = controller.validateEmail(testIdentityId)(FakeRequest())
       status(result) shouldEqual INTERNAL_SERVER_ERROR

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -111,7 +111,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updateRequest = IdentityUserUpdate(userUpdateRequest, Some(false))
       val updatedUser = user.copy(email = updateRequest.email)
 
-      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
+      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(\/-(None)))
       when(userWriteRepo.update(user, updateRequest)).thenReturn(Future.successful(\/-(updatedUser)))
       when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(\/-{}))
 
@@ -128,7 +128,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updateRequest = IdentityUserUpdate(userUpdateRequest, Some(false))
       val updatedUser = user.copy(email = updateRequest.email)
 
-      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
+      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(\/-(None)))
       when(userWriteRepo.update(user, updateRequest)).thenReturn(Future.successful(\/-(updatedUser)))
       when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(\/-{}))
 
@@ -144,7 +144,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updateRequest = IdentityUserUpdate(userUpdateRequest, Some(false))
       val updatedUser = user.copy(email = updateRequest.email)
 
-      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
+      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(\/-(None)))
       when(userWriteRepo.update(user, updateRequest)).thenReturn(Future.successful(\/-(updatedUser)))
 
       Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual \/-(updatedUser)
@@ -157,7 +157,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updateRequest = IdentityUserUpdate(userUpdateRequest, None)
       val updatedUser = user.copy(email = updateRequest.email)
 
-      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
+      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(\/-(None)))
       when(userWriteRepo.update(user, updateRequest)).thenReturn(Future.successful(\/-(updatedUser)))
 
       Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual \/-(updatedUser)
@@ -171,7 +171,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updateRequest = IdentityUserUpdate(userUpdateRequest, None)
       val updatedUser = user.copy(email = updateRequest.email)
 
-      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
+      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(\/-(None)))
       when(userWriteRepo.update(user, updateRequest)).thenReturn(Future.successful(\/-(updatedUser)))
 
       val result = service.update(user, userUpdateRequest)
@@ -208,7 +208,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val user = User("id", "email@theguardian.com")
       val updateRequest = UserUpdateRequest(email = "invalid", username = Some("username"))
 
-      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(Some(user)))
+      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(\/-(Some(user))))
 
       Await.result(service.update(user, updateRequest), 1.second) shouldEqual -\/(ApiError("Email is invalid"))
       verifyZeroInteractions(userWriteRepo)
@@ -218,7 +218,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val user = User("id", "email@theguardian.com")
       val updateRequest = UserUpdateRequest(email = "invalid", username = Some("123"))
 
-      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(Some(user)))
+      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(\/-(Some(user))))
 
       val result = service.update(user, updateRequest)
 
@@ -231,7 +231,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val userUpdateRequest = UserUpdateRequest(email = "email@theguardian.com", username = Some("username"))
       val updateRequest = IdentityUserUpdate(userUpdateRequest, None)
 
-      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(None))
+      when(userReadRepo.findByEmail(updateRequest.email)).thenReturn(Future.successful(\/-(None)))
       when(userWriteRepo.update(user, updateRequest)).thenReturn(Future.successful(-\/(ApiError("boom"))))
 
       Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual -\/(ApiError("boom"))


### PR DESCRIPTION
Replace `Future[Option[_]]` with `ApiResponse[Option[_]]` return type when searching mongo db to bring it in line with the rest of the code.