### PR TITLE
Conjoin Admin and Editorial subscriber status

### DIFF
--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -116,7 +116,7 @@ import scala.util.{Failure, Success, Try}
           List(adminSubscriber, editorialSubscriber).map(_.getStatus.value).forall(_ == "Active")
         }).getOrElse(false)
 
-      def whateverStatusIsInAdminBusinessUnit: Option[String] =
+      def adminBusinessUnitStatus: Option[String] =
         adminSubscriberOpt match {
           case Some(subscriber) => subscriber.getStatus.value match {
             case "Active" => Some("Active")
@@ -132,7 +132,7 @@ import scala.util.{Failure, Success, Try}
           Some("Unsubscribed")
       }
       else
-        whateverStatusIsInAdminBusinessUnit
+        adminBusinessUnitStatus
 
     }).run
   }


### PR DESCRIPTION
There is a possibility of subscriber being active in the Admin business unit, while unsubscribed (deactivated) in Editorial business unit. This PR makes sure that in this case our userhelp sees this users as unsubscribed. Also when userhelp activates the subscriber, it will do so in both business units in one go.

This helps alleviate the long standing bug where if the user is unsubscribed at Editorial business unit level, they cannot re-subscribe from the article pages such as:
https://www.theguardian.com/info/2015/dec/08/daily-email-uk
