### PR TITLE
Scientist port (for Mongo->RDS migration)

### DIFF
--- a/app/repositories/UsersWriteRepository.scala
+++ b/app/repositories/UsersWriteRepository.scala
@@ -97,7 +97,7 @@ import scalaz.std.scalaFuture._
         -\/(ApiError(title, error.getMessage))
       }
 
-  def unsubscribeFromMarketingEmails(email: String) =
+  def unsubscribeFromMarketingEmails(email: String): ApiResponse[User] =
     (for {
       persistedUser <- EitherT(findBy(email))
       statusFields = persistedUser.statusFields.getOrElse(StatusFields()).copy(receive3rdPartyMarketing = Some(false), receiveGnmMarketing = Some(false))

--- a/app/util/scientist/scientist.scala
+++ b/app/util/scientist/scientist.scala
@@ -1,0 +1,111 @@
+package util.scientist
+
+import ai.x.diff.DiffShow
+import com.typesafe.scalalogging.Logger
+import org.slf4j.{Logger => ILogger}
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+sealed trait Result
+case class Error(e: Throwable) extends Result
+case class Match[A](control: A, candidate: A) extends Result
+case class Ignore[A](control: A, candidate: A) extends Result
+case class MisMatch[A](control: A, candidate: A) extends Result
+
+object Defaults {
+
+  val logger = Logger("ScientistLogger")
+
+  def publish(logger: ILogger)(result: Result): Unit = result match {
+    case Error(e) => logger.error("Scientist error", e)
+    case MisMatch(control, candidate) => logger.error(DiffShow.diff(control, candidate).string)
+    case _ =>
+  }
+}
+
+case class SyncExperiment[A](
+  name: String,
+  control: () => A = () => ???,
+  candidate: () => A = () => ???,
+  publish: Result => Unit = println,
+  isEnabled: () => Boolean = () => true,
+  shouldIgnore: A => Boolean = (_: A) => false,
+  isEqual: (A, A) => Boolean = (_: A) == (_: A)
+) {
+
+  def using(
+    control: () => A,
+    candidate: () => A): SyncExperiment[A] = {
+
+    copy(control = control, candidate = candidate)
+  }
+}
+
+case class AsyncExperiment[A](
+  name: String,
+  control: () => Future[A] = () => ???,
+  candidate: () => Future[A] = () => ???,
+  publish: Result => Unit = println,
+  isEnabled: () => Boolean = () => true,
+  shouldIgnore: A => Boolean = (_: A) => false,
+  isEqual: (A, A) => Boolean = (_: A) == (_: A)
+) {
+
+  def using(
+    control: () => Future[A],
+    candidate: () => Future[A]): AsyncExperiment[A] = {
+
+    copy(control = control, candidate = candidate)
+  }
+}
+
+object Science {
+
+  lazy val callingThreadEC: ExecutionContext = new ExecutionContext {
+    override def reportFailure(cause: Throwable) = ExecutionContext.defaultReporter
+    override def execute(runnable: Runnable) = runnable.run()
+  }
+
+  def run[A](sync: SyncExperiment[A]): A = {
+    implicit val ec = callingThreadEC
+
+    val async = AsyncExperiment(
+      name = sync.name,
+      control = () => Future.apply(sync.control()),
+      candidate = () => Future.apply(sync.candidate()),
+      publish = sync.publish,
+      isEnabled = sync.isEnabled,
+      shouldIgnore = sync.shouldIgnore,
+      isEqual = sync.isEqual
+    )
+
+    Await.result(run(async), Duration.Inf)
+  }
+
+  def run[A](exp: AsyncExperiment[A])(implicit executor: ExecutionContext): Future[A] = {
+    val result = exp.control()
+
+    if (exp.isEnabled()) {
+      val candidateResult = exp.candidate()
+
+      for {
+        con <- result
+        can <- candidateResult
+      } {
+        val isEqual = exp.isEqual(con, can)
+
+        val msg =
+          if (exp.shouldIgnore(con)) Ignore(con, can)
+          else if (isEqual) Match(con, can)
+          else MisMatch(con, can)
+
+        exp.publish(msg)
+      }
+
+      candidateResult.onFailure { case e => exp.publish(Error(e)) }
+    }
+
+    result
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,16 +17,18 @@ object Dependencies {
   val emailValidation =     "uk.gov.hmrc"                   %% "emailaddress"             % "2.1.0"
   val exactTargetFuel =     "com.exacttarget"               %  "fuelsdk"                  % "1.1.0"
   val tip =                 "com.gu"                        %% "tip"                      % "0.3.2"
+  val diff =                "ai.x"                          %% "diff"                     % "1.2.0"
   val scalaTestPlus =       "org.scalatestplus.play"        %% "scalatestplus-play"       % "2.0.0"     % "test"
   val embeddedMongo =       "com.github.simplyscala"        %% "scalatest-embedmongo"     % "0.2.3"     % "test"
   val mockWs =              "de.leanovate.play-mockws"      %% "play-mockws"              % "2.5.1"     % "test"
   val scalaTest =           "org.scalatest"                 %% "scalatest"                % "3.0.1"     % "test"
   val akkaSlf4j =           "com.typesafe.akka"             %% "akka-slf4j"               % "2.4.17"    % "test"
   val akkaTestkit =         "com.typesafe.akka"             %% "akka-testkit"             % "2.4.17"    % "test"
+  val slf4jTesting =        "com.portingle"                 % "slf4jtesting"	            % "1.1.3"     % "test"
 
   val apiDependencies = Seq(scalaUri, identityCookie, identityPlayAuth, emailValidation,
     playWS, playCache, playFilters, awsWrap, scalaz, reactiveMongo,
     specs2, scalaTest, embeddedMongo, mockWs, scalaTestPlus, akkaSlf4j, akkaTestkit,
-    exactTargetFuel, tip, aws)
+    exactTargetFuel, tip, aws, diff, slf4jTesting)
 
 }

--- a/test/util/scientist/ScientistTest.scala
+++ b/test/util/scientist/ScientistTest.scala
@@ -1,0 +1,74 @@
+package util.scientist
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class ScientistTest extends FlatSpec with Matchers {
+
+  object Box {
+    var lastResult: Result = null
+    val publish: Result => Unit = result => Box.lastResult = result
+  }
+
+  case class Test[A](returns: A, expectedResult: Result, experiment: SyncExperiment[A])
+
+  // TODO - add test to ensure sync runs on current thread. As a quick test can
+  // use `println(Thread.currentThread().getName()`.
+
+  "Science" should "run and compare experiments" in {
+    val tests = List(
+      Test(
+        List(1, 2, 3),
+        MisMatch(List(1, 2, 3), List(2, 3, 4)),
+        SyncExperiment(
+          name = "a",
+          control = () => List(1, 2, 3),
+          candidate = () => List(2, 3, 4),
+          publish = Box.publish
+        )
+      )
+    )
+
+    tests.foreach { test =>
+      val returned = Science.run(test.experiment)
+      returned shouldBe test.returns
+      Box.lastResult shouldBe test.expectedResult
+    }
+  }
+
+  it should "ignore tests if requested" in {
+    def ignoreEvenFirst(list: List[Int]): Boolean = {
+      list.headOption.exists(_ % 2 == 0)
+    }
+
+    val tests = List(
+      Test(
+        List(1, 2, 3),
+        MisMatch(List(1, 2, 3), List(2, 3, 4)),
+        SyncExperiment[List[Int]](
+          name = "a",
+          control = () => List(1, 2, 3),
+          candidate = () => List(2, 3, 4),
+          publish = Box.publish,
+          shouldIgnore = ignoreEvenFirst
+        )
+      ),
+      Test(
+        List(2, 3),
+        Ignore(List(2, 3), List(2, 3, 4)),
+        SyncExperiment[List[Int]](
+          name = "a",
+          control = () => List(2, 3),
+          candidate = () => List(2, 3, 4),
+          publish = Box.publish,
+          shouldIgnore = ignoreEvenFirst
+        )
+      )
+    )
+
+    tests.foreach { test =>
+      val returned = Science.run(test.experiment)
+      returned shouldBe test.returns
+      Box.lastResult shouldBe test.expectedResult
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/github/scientist

*If this works out, I'll move it into a separate project, as it could be useful more generally.*

There is a Java implementation but I thought we could do it more simply and clearly in Scala.

I've also borrowed the 'ignore' behaviour, which looks very useful (for example, ignoring results less than 1 minute old to account for replication lag) but doesn't exist in the Java port.

And added, too, a default publish option using a library to diff case classes.

There are lots of ways to improve this:

* more tests and more reuse in the tests rather than so much copy+paste
* some better defaults/helpers and builders (the use of `???` is a bit error-prone I suspect)