### PR TITLE
Add consumer emails

### DIFF
--- a/app/configuration/Config.scala
+++ b/app/configuration/Config.scala
@@ -67,6 +67,10 @@ object Config {
       val clientSecret = config.getString("exacttarget.editorial.clientSecret")
       val clientId = config.getString("exacttarget.editorial.clientId")
     }
+    object Consumer {
+      val clientSecret = config.getString("exacttarget.consumer.clientSecret")
+      val clientId = config.getString("exacttarget.consumer.clientId")
+    }
   }
 
   object Discussion {

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -106,7 +106,11 @@ object NewslettersSubscription {
   implicit val format = Json.format[NewslettersSubscription]
 }
 
-case class ConsumerEmail(emailName: String, deliveredDate: String)
+case class ConsumerEmail(
+  emailName: String,
+  deliveredDate: String,
+  openTime: String
+)
 
 object ConsumerEmail {
   implicit val format = Json.format[ConsumerEmail]

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -106,7 +106,13 @@ object NewslettersSubscription {
   implicit val format = Json.format[NewslettersSubscription]
 }
 
-case class ConsumerEmails(list: List[String])
+case class ConsumerEmail(emailName: String, deliveredDate: String)
+
+object ConsumerEmail {
+  implicit val format = Json.format[ConsumerEmail]
+}
+
+case class ConsumerEmails(list: List[ConsumerEmail])
 
 object ConsumerEmails {
   implicit val format = Json.format[ConsumerEmails]

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -106,7 +106,16 @@ object NewslettersSubscription {
   implicit val format = Json.format[NewslettersSubscription]
 }
 
-case class ExactTargetSubscriber(status: String, newsletters: Option[NewslettersSubscription])
+case class ConsumerEmails(list: List[String])
+
+object ConsumerEmails {
+  implicit val format = Json.format[ConsumerEmails]
+}
+
+case class ExactTargetSubscriber(
+  status: String, newsletters:
+  Option[NewslettersSubscription],
+  consumerEmails: Option[ConsumerEmails])
 
 object ExactTargetSubscriber {
   implicit val format = Json.format[ExactTargetSubscriber]

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -5,7 +5,7 @@ import javax.inject.{Inject, Singleton}
 import com.exacttarget.fuelsdk._
 import com.gu.identity.util.Logging
 import configuration.Config
-import models.{ApiError, ApiResponse, ExactTargetSubscriber, NewslettersSubscription}
+import models._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scalaz.std.scalaFuture._
@@ -79,6 +79,26 @@ import scala.util.{Failure, Success, Try}
     }.run
   }
 
+  def consumerEmailsByEmail(email: String): ApiResponse[Option[ConsumerEmails]] = {
+
+    val recordsFromDeT: EitherT[Future, ApiError, Option[List[ETDataExtensionRow]]] =
+
+      EitherT(retrieveDataExtension("B2FD61EE-00C2-44A2-B10F-3D7DD308D9CE", etClientConsumer)).flatMap {
+        case Some(de) =>
+          EitherT(selectFromDataExtension(s"SubscriberKey=$email", de))
+
+        case None => EitherT.right(Future.successful(None))
+      }
+
+    recordsFromDeT.map {
+      case Some(rows) =>
+        val consumerEmails = rows.map(row => s"${row.getColumn("EmailName")} - ${row.getColumn("DeliveredTime")}")
+        (Some(ConsumerEmails(consumerEmails)))
+
+      case None => None
+    }.run
+  }
+
   def deleteSubscriber(email: String): ApiResponse[Unit] =
     EitherT(retrieveSubscriber(email, etClientAdmin)).flatMap {
       case Some(subscriber) => EitherT(deleteSubscriber(subscriber))
@@ -140,14 +160,16 @@ import scala.util.{Failure, Success, Try}
   def subscriberByEmail(email: String): ApiResponse[Option[ExactTargetSubscriber]] = {
     val statusF = EitherT(status(email))
     val newslettersF = EitherT(newslettersSubscriptionByEmail(email))
+    val consumerEmailsF = EitherT(consumerEmailsByEmail(email))
 
     val subByEmailT =
       for {
         statusOpt <- statusF
         newslettersOpt <- newslettersF
+        consumerEmailsOpt <- consumerEmailsF
       } yield {
         statusOpt match {
-          case Some(status) => Some(ExactTargetSubscriber(status, newslettersOpt))
+          case Some(status) => Some(ExactTargetSubscriber(status, newslettersOpt, consumerEmailsOpt))
           case None => None
         }
       }
@@ -202,6 +224,46 @@ import scala.util.{Failure, Success, Try}
     }
   }
 
+  private def retrieveDataExtension(key: String, client: ETClient): ApiResponse[Option[ETDataExtension]] = Future {
+
+    val retrieveTry = Try {
+      Option(client.retrieve(classOf[ETDataExtension], s"key=$key").getResult) match {
+        case Some(result) => \/-(Some(result.getObject))
+        case None => \/-(Option.empty[ETDataExtension])
+      }
+    }
+
+    retrieveTry match {
+      case Success(result) => result
+
+      case Failure(error) =>
+        val title = s"Failed to retrieve DataExtension $key from ExactTarget"
+        logger.error(title, error)
+        -\/(ApiError(title, error.getMessage))
+    }
+  }
+
+  private def selectFromDataExtension(
+      query: String,
+      de: ETDataExtension): ApiResponse[Option[List[ETDataExtensionRow]]] = Future {
+
+    val retrieveTry = Try {
+      Option(de.select(query).getObjects) match {
+        case Some(results) => \/-(Some(results.toList))
+        case None => \/-(Option.empty[List[ETDataExtensionRow]])
+      }
+    }
+
+    retrieveTry match {
+      case Success(result) => result
+
+      case Failure(error) =>
+        val title = s"Failed to retrieve DataExtension records from ExactTarget"
+        logger.error(title, error)
+        -\/(ApiError(title, error.getMessage))
+    }
+  }
+
   private def deleteSubscriber(subscriber: ETSubscriber): ApiResponse[Unit] = Future {
     val etResponse = etClientAdmin.delete(subscriber)
     handleETResponse(etResponse, "Failed to delete ExactTarget subscriber")
@@ -236,6 +298,13 @@ import scala.util.{Failure, Success, Try}
     val etConf = new ETConfiguration()
     etConf.set("clientId", Config.ExactTarget.Editorial.clientId)
     etConf.set("clientSecret", Config.ExactTarget.Editorial.clientSecret)
+    new ETClient(etConf)
+  }
+
+  private lazy val etClientConsumer = {
+    val etConf = new ETConfiguration()
+    etConf.set("clientId", Config.ExactTarget.Consumer.clientId)
+    etConf.set("clientSecret", Config.ExactTarget.Consumer.clientSecret)
     new ETClient(etConf)
   }
 }

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -92,7 +92,7 @@ import scala.util.{Failure, Success, Try}
 
     recordsFromDeT.map {
       case Some(rows) =>
-        val consumerEmails = rows.map(row => s"${row.getColumn("EmailName")} - ${row.getColumn("DeliveredTime")}")
+        val consumerEmails = rows.map(row => ConsumerEmail(row.getColumn("EmailName"),  row.getColumn("DeliveredTime")))
         (Some(ConsumerEmails(consumerEmails)))
 
       case None => None

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -92,8 +92,15 @@ import scala.util.{Failure, Success, Try}
 
     recordsFromDeT.map {
       case Some(rows) =>
-        val consumerEmails = rows.map(row => ConsumerEmail(row.getColumn("EmailName"),  row.getColumn("DeliveredTime")))
-        (Some(ConsumerEmails(consumerEmails)))
+        val consumerEmails = rows.map { row =>
+          ConsumerEmail(
+            row.getColumn("EmailName"),
+            row.getColumn("DeliveredTime"),
+            row.getColumn("OpenTime")
+          )
+        }
+
+        Some(ConsumerEmails(consumerEmails))
 
       case None => None
     }.run

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -79,6 +79,13 @@ import scala.util.{Failure, Success, Try}
     }.run
   }
 
+  /**
+    * In Consumer BU:
+    *   Data Extension:   'All Emails Sent' B2FD61EE-00C2-44A2-B10F-3D7DD308D9CE
+    *   SQL Query:        'All Emails Sent' 5ca82872-97ee-42d9-8764-38a2da937a7b
+    *   Automation:       'All Emails Sent' 4c4ea8e4-f541-5aa7-591e-0bbcd3327ea8
+    *   API Integration:  'All Emails Sent' 82e38185-322d-438b-a9f6-63f2cd37e252
+    */
   def consumerEmailsByEmail(email: String): ApiResponse[Option[ConsumerEmails]] = {
 
     val recordsFromDeT: EitherT[Future, ApiError, Option[List[ETDataExtensionRow]]] =


### PR DESCRIPTION
All the Consumer emails sent in the last 6 months. 

In Marketing Cloud, a new [Data Extension](https://help.marketingcloud.com/en/documentation/exacttarget/subscribers/data_extensions_for_exacttarget_marketing_cloud/) (essentially a table) has been created which is populated by an [SQL Query Activity](https://help.marketingcloud.com/en/documentation/exacttarget/interactions/activities/query_activity/) which runs periodically via [Automation Studio](https://help.marketingcloud.com/en/documentation/automation_studio/). The SQL query retrieves and joins data from multiple [Data Views](http://help.marketingcloud.com/en/documentation/automation_studio/using_automation_studio_activities/using_the_query_activity/data_views/data_view_sent/).

In Consumer BU:

| Component  | Name | Key |
| ------------- | ------------- | ------------- |
|  Data Extension | All Emails Sent  | B2FD61EE-00C2-44A2-B10F-3D7DD308D9CE |
| SQL Query | All Emails Sent  | 5ca82872-97ee-42d9-8764-38a2da937a7b |
| Automation | All Emails Sent | 4c4ea8e4-f541-5aa7-591e-0bbcd3327ea8 |
| API Integration | All Emails Sent | 82e38185-322d-438b-a9f6-63f2cd37e252 |

The code in this PR is not aware of the above process as it only retrieves whatever is in the data extension.

Related PR: https://github.com/guardian/identity-admin/pull/196