### PR TITLE
Add contributions

### DIFF
--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -131,11 +131,16 @@ object ExactTargetSubscriber {
   implicit val format = Json.format[ExactTargetSubscriber]
 }
 
+case class Contribution(date: String, currency: String, amount: String)
+
+object Contribution {
+  implicit val format = Json.format[Contribution]
+}
+
 case class User(id: String,
                 email: String,
                 displayName: Option[String] = None,
                 username: Option[String] = None,
-                vanityUrl: Option[String] = None,
                 personalDetails: PersonalDetails = PersonalDetails(),
                 deliveryAddress: Address = Address(),
                 billingAddress: Address = Address(),
@@ -152,7 +157,8 @@ case class User(id: String,
                 exactTargetSubscriber: Option[ExactTargetSubscriber] = None,
                 hasCommented: Boolean = false,
                 deleted: Boolean = false,
-                orphan: Boolean = false
+                orphan: Boolean = false,
+                contributions: List[Contribution] = Nil
                )
 
 object User {
@@ -164,7 +170,6 @@ object User {
                 email = user.primaryEmailAddress,
                 displayName = user.publicFields.flatMap(_.displayName),
                 username = user.publicFields.flatMap(_.username),
-                vanityUrl = user.publicFields.flatMap(_.vanityUrl),
                 personalDetails = PersonalDetails(
                  firstName = user.privateFields.flatMap(_.firstName),
                  lastName = user.privateFields.flatMap(_.secondName),


### PR DESCRIPTION
Add contributions by using Marketing Cloud data extension:

 'TriggeredSendDataExtension - allcontributors' 2AF90B07-0DE8-42A4-B549-3B808C77F56C

Corresponding frontend PR: https://github.com/guardian/identity-admin/pull/197

Unrelated to above, I've removed `vanityUrl` as it is not needed and it seems there is a limit in the number of fields in a case class that play-json can parse:
https://stackoverflow.com/questions/23571677/22-fields-limit-in-scala-2-11-play-framework-2-3-case-classes-and-functions