### PR TITLE
Correct stack name and cloudform by tags

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -12,10 +12,10 @@ deployments:
       - update-ami
   update-ami:
     type: ami-cloudformation-parameter
+    app: identity-admin-api
     parameters:
-      cloudFormationStackByTags: false
       prependStackToCloudFormationStackName: false
-      cloudFormationStackName: IdentityAdminAPI
+      cloudFormationStackName: IdentityAdminApi
       amiParametersToTags:
         AMI:
           Recipe: identity-base


### PR DESCRIPTION
- Cloudform by tag name because the CODE and PROD stacks have different naming conventions.
- Prod is IdentityAdminApi and Code is IdentityAdminAPI
- This change means the identityAdminApi stacks should be tagged like: 
     - App: identity-admin-api
     - Stack: identity
     - Stage: CODE/PROD