### PR TITLE
Add permissions to allow ssh key fetching

### DIFF
--- a/cloudformation/identity-admin-api.yaml
+++ b/cloudformation/identity-admin-api.yaml
@@ -140,6 +140,10 @@ Resources:
             Resource:
             - !Sub arn:aws:s3:::identity-artifacts/${Stage}/${App}/*
             - !Sub arn:aws:s3:::identity-private-config/${Stage}/${App}/*
+            - arn:aws:s3:::github-public-keys/*
+          - Effect: Allow
+            Action: s3:ListBucket
+            Resource: arn:aws:s3:::github-public-keys
           - Effect: Allow
             Action: ec2:Describe*
             Resource: '*'


### PR DESCRIPTION
The fetching of SSH keys was not working after AMI creation due to this missing s3 permission.
