### PR TITLE
Fixed Contribution date coming out of Identity Admin API

### DIFF
--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -20,8 +20,8 @@ import scala.util.{Failure, Success, Try}
 @Singleton class ExactTargetService @Inject() (
     usersReadRepository: UsersReadRepository)(implicit ec: ExecutionContext) extends Logging {
 
-  private val dateTimeFormatterUSA = DateTimeFormat.forPattern("MM/dd/yyyy hh:mm:ss a")
-  private val dateTimeFormatterGBR = DateTimeFormat.forPattern("dd/MM/yyyy hh:mm:ss a")
+  private val dateTimeFormatterUSA = DateTimeFormat.forPattern("MM/dd/yyyy h:mm:ss a")
+  private val dateTimeFormatterGBR = DateTimeFormat.forPattern("dd/MM/yyyy h:mm:ss a")
 
   /**
     * Unsubscribe this subscriber from all current and future subscriber lists.

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -20,8 +20,8 @@ import scala.util.{Failure, Success, Try}
 @Singleton class ExactTargetService @Inject() (
     usersReadRepository: UsersReadRepository)(implicit ec: ExecutionContext) extends Logging {
 
-  private val dateTimeFormatterUSA = DateTimeFormat.forPattern("MM/dd/yyyy HH:mm:ss")
-  private val dateTimeFormatterGBR = DateTimeFormat.forPattern("dd/MM/yyyy HH:mm:ss")
+  private val dateTimeFormatterUSA = DateTimeFormat.forPattern("MM/dd/yyyy hh:mm:ss a")
+  private val dateTimeFormatterGBR = DateTimeFormat.forPattern("dd/MM/yyyy hh:mm:ss a")
 
   /**
     * Unsubscribe this subscriber from all current and future subscriber lists.


### PR DESCRIPTION
I spotted a display issue in the User Admin tool for Contribution dates which might confuse people who look at it as it's in USA date format. So this PR is a suggested fix. I'm happy to put this in the User Admin front end if you'd prefer, however here seemed more appropriate.

<img width="596" alt="picture 385" src="https://user-images.githubusercontent.com/1515970/37149789-37c47bbe-22c7-11e8-97d3-8d688ca3ba83.png">

cc @jfsoul @mario-galic @joelochlann 
