### PR TITLE
Unsubscribe only editorial BU and remove defunct methods

### DIFF
--- a/app/controllers/UsersController.scala
+++ b/app/controllers/UsersController.scala
@@ -112,14 +112,9 @@ import models.client.ApiError._
   }
 
   def unsubcribeFromAllEmailLists(email: String) = auth.async { request =>
-    logger.info("Unsubscribing from all email lists (marketing and editorial)")
-    val unsubscribeMarketingEmailsInIdentity = EitherT(exactTargetService.unsubscribeFromAllLists(email))
-    val unsubcribeAllEmailsInExactTarget = EitherT(userService.unsubscribeFromMarketingEmails(email))
+    logger.info("Unsubscribing from all editorial email lists ")
 
-    (for {
-      _ <- unsubscribeMarketingEmailsInIdentity
-      _ <- unsubcribeAllEmailsInExactTarget
-    } yield ()).fold(
+    EitherT(exactTargetService.unsubscribeFromAllLists(email)).fold(
       error => {
         logger.error(s"Failed to unsubscribe from all email lists: $error")
         InternalServerError(error)

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -27,18 +27,12 @@ import scala.util.{Failure, Success, Try}
   /**
     * Unsubscribe this subscriber from all current and future subscriber lists.
     */
-  def unsubscribeFromAllLists(email: String): ApiResponse[Unit] = {
-    val adminStatusUpdateF = EitherT(updateSubscriptionStatus(email, ETSubscriber.Status.UNSUBSCRIBED, etClientAdmin))
-    val editorialStatusUpdateF = EitherT(updateSubscriptionStatus(email, ETSubscriber.Status.UNSUBSCRIBED, etClientEditorial))
-
-    (for {
-      _ <- adminStatusUpdateF
-      _ <- editorialStatusUpdateF
-    } yield {}).run
-  }
+  def unsubscribeFromAllLists(email: String): ApiResponse[Unit] =
+    EitherT(updateSubscriptionStatus(email, ETSubscriber.Status.UNSUBSCRIBED, etClientEditorial)).run
 
   /**
     * Activates subscriber in both Admin and Editorial business units.
+    * We activate in Admin to be safe because we used to unsubscribe there too.
     */
   def activateEmailSubscription(email: String): ApiResponse[Unit] = {
     val adminStatusUpdateF = EitherT(updateSubscriptionStatus(email, ETSubscriber.Status.ACTIVE, etClientAdmin))

--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -262,10 +262,6 @@ import scalaz.{-\/, EitherT, \/, \/-}
       _ <- EitherT(identityApiClient.sendEmailValidation(user.id))
     } yield()).run
 
-  def unsubscribeFromMarketingEmails(email: String): ApiResponse[Int] = {
-    postgresUsersReadRepository.unsubscribeFromMarketingEmails(email)
-  }
-
   def enrichUserWithProducts(user: GuardianUser): ApiResponse[GuardianUser]  = {
     val subscriptionF = EitherT(salesforceService.getSubscriptionByIdentityId(user.idapiUser.id))
     val membershipF = EitherT(salesforceService.getMembershipByIdentityId(user.idapiUser.id))

--- a/test/repositories/postgres/PostgresUserRepositoryTest.scala
+++ b/test/repositories/postgres/PostgresUserRepositoryTest.scala
@@ -144,18 +144,6 @@ class PostgresUserRepositoryTest extends WordSpecLike
     }
   }
 
-  "PostgresUserRepository#unsubscribeFromMarketingEmails" should {
-    "Unsub from marketing mails" in new TestFixture {
-      whenReady(
-        repo.unsubscribeFromMarketingEmails("identitydev@guardian.co.uk")
-          .flatMap(_ => repo.findById("1234"))
-      ) {
-        case \/-(Some(updatedUser)) => updatedUser.status.receive3rdPartyMarketing shouldBe Some(false)
-        case _ => fail()
-      }
-    }
-  }
-
   "PostgresUserRepository#updateEmailValidationStatus" should {
     "Unsub from marketing mails" in new TestFixture {
       whenReady(


### PR DESCRIPTION
We no longer want to unsubscribe users from admin BU in Exact Target.  I've also removed some old marketing unsubscribe behaviour which has been replaced.