### PR TITLE
Salesforce auth token to akka token

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,7 @@ object Dependencies {
     "org.scalatestplus.play"      %%  "scalatestplus-play"    % "3.1.1"           % "test",
     "com.typesafe.akka"           %%  "akka-slf4j"            % "2.5.4"           % "test",
     "com.typesafe.akka"           %%  "akka-testkit"          % "2.5.4"           % "test",
-    PlayImport.specs2                                                             % "test"
+    "com.typesafe.akka"           %%  "akka-agent"            % "2.5.6",
+  PlayImport.specs2                                                             % "test"
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,6 @@ object Dependencies {
     "org.scalatestplus.play"      %%  "scalatestplus-play"    % "3.1.1"           % "test",
     "com.typesafe.akka"           %%  "akka-slf4j"            % "2.5.4"           % "test",
     "com.typesafe.akka"           %%  "akka-testkit"          % "2.5.4"           % "test",
-    "com.typesafe.akka"           %%  "akka-agent"            % "2.5.6",
-  PlayImport.specs2                                                             % "test"
+    PlayImport.specs2                                                             % "test"
   )
 }


### PR DESCRIPTION
Previously the salesforce token was stored in a val that was obtained on startup, it then never refreshed itself. The token expires after 12 hours of inactivity so the app would be trying to use an expired token until it was redeployed and requested a fresh token. 

- Use a cache for the salesforce token. If it hasn't been used in 15 minutes request a fresh token. 

