### PR TITLE
speed up admin queries by using gin index

### DIFF
--- a/test/repositories/postgres/PostgresUserRepositoryTest.scala
+++ b/test/repositories/postgres/PostgresUserRepositoryTest.scala
@@ -2,7 +2,6 @@ package repositories.postgres
 
 import actors.MetricsActorProviderStub
 import akka.actor.ActorSystem
-import com.google.common.util.concurrent.MoreExecutors
 import models.client.{ApiResponse, SearchResponse, User, UserUpdateRequest}
 import models.database.mongo._
 import models.database.postgres.PostgresUserRepository
@@ -12,9 +11,7 @@ import org.scalatest.time.{Milliseconds, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, Matchers, WordSpecLike}
 import play.api.libs.json.Json
 import scalikejdbc._
-import support.PgTestUtils
-
-import scala.concurrent.ExecutionContext
+import support.{EmbeddedPostgresSupport, PgTestUtils}
 import scalaz.\/-
 import scalaz.syntax.std.option._
 


### PR DESCRIPTION
The GIN index seems faster having tested with PG explain analyze
It's strange since queries to the old #>> index for {searchFields,emailAddress} are fast (< 10ms) whereas the other fields are relatively slow (> 500ms), even though they use the same searchFields index.

Vacuum analyze did not speed things up
