### PR TITLE
speed up search query for users found in identity database

### DIFF
--- a/app/ErrorHandler.scala
+++ b/app/ErrorHandler.scala
@@ -5,11 +5,11 @@ import play.api.mvc.Results._
 
 import scala.concurrent._
 import javax.inject.Singleton
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import models.client.ApiError
 
 @Singleton
-class ErrorHandler extends HttpErrorHandler with Logging {
+class ErrorHandler extends HttpErrorHandler with LazyLogging {
   def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
     if(statusCode == play.mvc.Http.Status.BAD_REQUEST) {
       logger.debug(s"Bad request: $request, error: $message")

--- a/app/actions/AuthenticatedAction.scala
+++ b/app/actions/AuthenticatedAction.scala
@@ -5,7 +5,7 @@ import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import javax.inject._
 
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import org.apache.commons.codec.binary.Base64
 import org.joda.time.{DateTime, DateTimeZone}
@@ -36,7 +36,7 @@ object HmacSigner {
   }
 }
 
-object HmacAuthenticator extends Logging {
+object HmacAuthenticator extends LazyLogging {
   val secret = Config.hmacSecret
 
   val HmacPattern = "HMAC\\s(.+)".r
@@ -69,7 +69,7 @@ object HmacAuthenticator extends Logging {
 }
 
 class AuthenticatedAction @Inject() (val parser: BodyParsers.Default)(implicit val executionContext: ExecutionContext)
-    extends ActionBuilder[Request, AnyContent] with Logging {
+    extends ActionBuilder[Request, AnyContent] with LazyLogging {
 
   def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
     Try {

--- a/app/actors/EventPublishingActor.scala
+++ b/app/actors/EventPublishingActor.scala
@@ -4,7 +4,7 @@ import actors.EventPublishingActor.{DisplayNameChanged, EmailValidationChanged}
 import akka.actor.{Actor, Props}
 import com.amazonaws.services.sns.AmazonSNSAsync
 import com.amazonaws.services.sns.model.PublishRequest
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import net.liftweb.json.{DefaultFormats, NoTypeHints, Serialization}
 import scala.util.{Failure, Success, Try}
@@ -23,7 +23,7 @@ object EventPublishingActor {
 
 }
 
-class EventPublishingActor(amazonSNSAsyncClient: AmazonSNSAsync) extends Actor with Logging {
+class EventPublishingActor(amazonSNSAsyncClient: AmazonSNSAsync) extends Actor with LazyLogging {
 
   import net.liftweb.json.Serialization.write
 

--- a/app/controllers/UsersController.scala
+++ b/app/controllers/UsersController.scala
@@ -4,7 +4,7 @@ import models.client.ClientJsonFormats._
 import javax.inject.{Inject, Singleton}
 
 import actions.{AuthenticatedAction, IdentityUserAction, OrphanUserAction}
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import com.gu.tip.Tip
 import configuration.Config
 import play.api.data.Forms._
@@ -31,7 +31,7 @@ import models.client.ApiError._
     orphanUserAction: OrphanUserAction,
     salesforce: SalesforceService,
     discussionService: DiscussionService,
-    exactTargetService: ExactTargetService)(implicit ec: ExecutionContext) extends AbstractController(cc) with Logging {
+    exactTargetService: ExactTargetService)(implicit ec: ExecutionContext) extends AbstractController(cc) with LazyLogging {
 
   def search(query: String, limit: Option[Int], offset: Option[Int]) = auth.async { request =>
     import Config.SearchValidation._

--- a/app/models/database/postgres/PostgresUserRepository.scala
+++ b/app/models/database/postgres/PostgresUserRepository.scala
@@ -20,7 +20,7 @@ class PostgresUserRepository @Inject()(val actorSystem: ActorSystem,
                                        val metricsActorProvider: MetricsActorProvider) extends LazyLogging
   with PostgresJsonFormats
   with PostgresUtils
-  with MetricsSupport{
+  with MetricsSupport {
 
   implicit val ec = ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
 

--- a/app/monitoring/CloudWatch.scala
+++ b/app/monitoring/CloudWatch.scala
@@ -46,11 +46,15 @@ case class Samples(samples: Map[SampleId, List[Sample]] = Map()) {
   }
 
   def toAmazonRequests(dimensions: Dimension*): Seq[PutMetricDataRequest] = {
-    groupByNamespace.map { case (namepsace, samps) =>
+    for {
+      (namepsace, namespaceSamples) <- groupByNamespace.toSeq
+      amazonStats = namespaceSamples.toAmazonStats(dimensions: _*)
+      groupedStats <- amazonStats.grouped(20)
+    } yield {
       new PutMetricDataRequest()
         .withNamespace(namepsace)
-        .withMetricData(samps.toAmazonStats(dimensions:_*).asJava)
-    }.toSeq
+        .withMetricData(groupedStats.asJava)
+    }
   }
 }
 

--- a/app/monitoring/CloudWatch.scala
+++ b/app/monitoring/CloudWatch.scala
@@ -3,7 +3,7 @@ package monitoring
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClientBuilder
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StatisticSet}
 import com.google.inject.ImplementedBy
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -63,7 +63,7 @@ trait Metrics {
   def publishCount(name : String, count: Double): Unit
 }
 
-class CloudWatch extends Metrics with Logging {
+class CloudWatch extends Metrics with LazyLogging {
 
   private val application = Config.applicationName
   private val stageDimension: Dimension = new Dimension().withName("Stage").withValue(Config.stage)

--- a/app/services/DiscussionService.scala
+++ b/app/services/DiscussionService.scala
@@ -2,7 +2,7 @@ package services
 
 import javax.inject.{Inject, Singleton}
 
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import models.client.{ApiError, ApiResponse}
 import play.api.http.Status
@@ -18,7 +18,7 @@ object DiscussionStats {
   implicit val format = Json.format[DiscussionStats]
 }
 
-@Singleton class DiscussionService @Inject() (ws: WSClient)(implicit ec: ExecutionContext) extends Logging {
+@Singleton class DiscussionService @Inject() (ws: WSClient)(implicit ec: ExecutionContext) extends LazyLogging {
   def hasCommented(id: String): ApiResponse[Boolean] = {
     ws.url(s"${Config.Discussion.apiUrl}/profile/$id/stats").get().map { response =>
       if (response.status == Status.NOT_FOUND) {

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -2,11 +2,11 @@ package services
 
 import com.amazonaws.services.simpleemail._
 import com.amazonaws.services.simpleemail.model._
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import scala.util.{Failure, Success, Try}
 
-object EmailService extends Logging {
+object EmailService extends LazyLogging {
   private val client = AmazonSimpleEmailServiceAsyncClientBuilder.standard()
       .withCredentials(Config.AWS.credentialsProvider)
       .withRegion(Config.AWS.region)

--- a/app/services/ExactTargetService.scala
+++ b/app/services/ExactTargetService.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.exacttarget.fuelsdk._
 import com.exacttarget.fuelsdk.internal.Options.SaveOptions
 import com.exacttarget.fuelsdk.internal.{CreateOptions, CreateRequest, CreateResponse, SaveAction, SaveOption, Subscriber, SubscriberList, SubscriberStatus}
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import javax.inject.{Inject, Singleton}
 import models.client._
@@ -18,7 +18,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 @Singleton class ExactTargetService @Inject()(postgresUsersReadRepository: PostgresUserRepository)
-                                             (implicit ec: ExecutionContext, actorSystem: ActorSystem) extends Logging {
+                                             (implicit ec: ExecutionContext, actorSystem: ActorSystem) extends LazyLogging {
 
   private val dateTimeFormatterUSA = DateTimeFormat.forPattern("MM/dd/yyyy h:mm:ss a")
   private val dateTimeFormatterGBR = DateTimeFormat.forPattern("dd/MM/yyyy h:mm:ss a")

--- a/app/services/IdentityApiClient.scala
+++ b/app/services/IdentityApiClient.scala
@@ -2,7 +2,7 @@ package services
 
 import javax.inject.Inject
 
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import models.client.{ApiError, ApiResponse}
 import play.api.libs.json.Json
@@ -23,7 +23,7 @@ object IdentityApiErrorResponse {
   implicit val format = Json.format[IdentityApiErrorResponse]
 }
 
-class IdentityApiClient @Inject() (ws: WSClient)(implicit ec: ExecutionContext) extends Logging {
+class IdentityApiClient @Inject() (ws: WSClient)(implicit ec: ExecutionContext) extends LazyLogging {
 
   val baseUrl = Config.IdentityApi.baseUrl
   val clientToken = Config.IdentityApi.clientToken

--- a/app/services/MadgexService.scala
+++ b/app/services/MadgexService.scala
@@ -2,7 +2,7 @@ package services
 
 import javax.inject.{Inject, Singleton}
 
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import util.UserConverter._
 import models.client.{GNMMadgexUser, MadgexUser}
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import play.api.libs.json.Json
 
 @Singleton class MadgexService @Inject() (
-    ws: WSClient, requestSigner: RequestSigner)(implicit ec: ExecutionContext) extends Logging {
+    ws: WSClient, requestSigner: RequestSigner)(implicit ec: ExecutionContext) extends LazyLogging {
 
   implicit val format = Json.format[MadgexUser]
 

--- a/app/services/RequestSigner.scala
+++ b/app/services/RequestSigner.scala
@@ -5,7 +5,7 @@ import javax.crypto.spec.SecretKeySpec
 import javax.inject.{Inject, Singleton}
 
 import com.google.inject.ImplementedBy
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.codec.binary.Base64
 import org.joda.time.DateTime
 import play.api.Configuration
@@ -19,7 +19,7 @@ import util.Formats
 }
 
 @ImplementedBy(classOf[RequestSignerWithSecret])
-trait RequestSigner extends Logging {
+trait RequestSigner extends LazyLogging {
 
   def secret: String
 

--- a/app/services/SalesforceIntegration.scala
+++ b/app/services/SalesforceIntegration.scala
@@ -5,14 +5,14 @@ import javax.inject._
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.services.sns.AmazonSNSClientBuilder
 import com.amazonaws.services.sns.model.PublishResult
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config
 import play.api.libs.json.Json
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-@Singleton class SalesforceIntegration @Inject() ()(implicit ec: ExecutionContext) extends Logging {
+@Singleton class SalesforceIntegration @Inject() ()(implicit ec: ExecutionContext) extends LazyLogging {
   private val snsTopic = Config.IdentitySalesforceQueue.snsTopic
   private val snsEndpoint = Config.IdentitySalesforceQueue.snsEndPoint
 

--- a/app/services/SalesforceService.scala
+++ b/app/services/SalesforceService.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.NotUsed
 import javax.inject.{Inject, Singleton}
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config.TouchpointSalesforce._
 import models.client._
 import play.api.libs.json.{JsArray, Json}
@@ -41,7 +41,7 @@ case class IdentityId(value: String, fieldName: String = "Zuora__Subscription__r
 case class Email(value: String, fieldName: String = "Zuora__Subscription__r.Zuora__CustomerAccount__r.Contact__r.Email") extends UniqueIdentifier
 case class SubscriptionId(value: String, fieldName: String = "Subscription_Name__c") extends UniqueIdentifier
 
-@Singleton class SalesforceService @Inject() (ws: WSClient, actorSystem: ActorSystem)(implicit ec: ExecutionContext) extends Logging {
+@Singleton class SalesforceService @Inject() (ws: WSClient, actorSystem: ActorSystem)(implicit ec: ExecutionContext) extends LazyLogging {
 
   val cacheLoader = new CacheLoader[NotUsed, SFAuthentication] {
    override def load(k: NotUsed) : SFAuthentication = {

--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -6,7 +6,7 @@ import actors.EventPublishingActor.{DisplayNameChanged, EmailValidationChanged}
 import actors.EventPublishingActorProvider
 import actors.metrics.{MetricsActorProvider, MetricsSupport}
 import akka.actor.ActorSystem
-import com.gu.identity.util.Logging
+import com.typesafe.scalalogging.LazyLogging
 import configuration.Config.PublishEvents.eventsEnabled
 import models.{client, _}
 import models.client._
@@ -31,7 +31,7 @@ import scalaz.{-\/, EitherT, \/-}
     postgresReservedUsernameRepository: PostgresReservedUsernameRepository,
     postgresUsersReadRepository: PostgresUserRepository,
     val metricsActorProvider: MetricsActorProvider)
-    (implicit ec: ExecutionContext, val actorSystem: ActorSystem) extends Logging with MetricsSupport {
+    (implicit ec: ExecutionContext, val actorSystem: ActorSystem) extends LazyLogging with MetricsSupport {
 
   private implicit val metricsNamespace = MetricsSupport.Namespace("identity-admin")
 

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -1,6 +1,6 @@
 package services
 
-import actors.EventPublishingActorProvider
+import actors.{EventPublishingActorProvider, MetricsActorProviderStub}
 import akka.actor.ActorSystem
 import models.client._
 import models.database.postgres.{PostgresDeletedUserRepository, PostgresReservedUsernameRepository, PostgresUserRepository}
@@ -41,7 +41,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
   val service =
     spy(new UserService(identityApiClient,
       eventPublishingActorProvider, salesforceService, salesforceIntegration, madgexService, exactTargetService,
-      discussionService, pgDeletedUserRepo, pgReservedUsernameRepo, pgUserRepo))
+      discussionService, pgDeletedUserRepo, pgReservedUsernameRepo, pgUserRepo, MetricsActorProviderStub))
 
   before {
     Mockito.reset(identityApiClient, eventPublishingActorProvider, service, madgexService, pgDeletedUserRepo, pgReservedUsernameRepo, pgUserRepo)


### PR DESCRIPTION
speed up admin queries for users found in identity database

- Add metrics for slow requests
- Only wait for slow third party queries if nothing found in identity database
- use LazyLogging everywhere, they started conflicting 😢 