### PR TITLE
set logstash memory to 500m

### DIFF
--- a/cloudformation/identity-admin-api.yaml
+++ b/cloudformation/identity-admin-api.yaml
@@ -320,6 +320,10 @@ Resources:
 
             instanceid=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 
+            # Set logstash memory
+            sed -i 's/-Xms.*/-Xms500m/g' /etc/logstash/jvm.options
+            sed -i 's/-Xmx.*/-Xmx500m/g' /etc/logstash/jvm.options
+
             cat > /etc/logstash/conf.d/logstash.conf <<__END__
             input {
                 stdin { }


### PR DESCRIPTION
systemd is killing the api since too much memory on the machine is used