### PR TITLE
Check reserved emails for email change on user admin tool 

### DIFF
--- a/app/models/database/postgres/PostgresReservedEmailRepository.scala
+++ b/app/models/database/postgres/PostgresReservedEmailRepository.scala
@@ -1,0 +1,28 @@
+package models.database.postgres
+
+import actors.metrics.{MetricsActorProvider, MetricsSupport}
+import com.google.inject.Inject
+import com.typesafe.scalalogging.LazyLogging
+import models.client.ApiResponse
+import net.liftweb.json.JsonDSL._
+import net.liftweb.json.compactRender
+import scalikejdbc._
+
+import scala.concurrent.ExecutionContext
+
+class PostgresReservedEmailRepository @Inject()(val metricsActorProvider: MetricsActorProvider)(implicit ec: ExecutionContext) extends LazyLogging
+  with PostgresJsonFormats
+  with PostgresUtils
+  with MetricsSupport {
+
+  def isReserved(email: String): ApiResponse[Boolean] = {
+    val emailMatcher = compactRender("email" -> email)
+    val sql =
+      sql"""
+           | select count(*) from reservedemails where (jdoc@>${emailMatcher}::jsonb)
+      """.stripMargin
+    readOnly { implicit session =>
+      sql.map(_.int(1)).single().apply().getOrElse(0) > 0
+    }(logFailure(s"Failed to check if the email $email is reserved"))
+  }
+}

--- a/app/models/database/postgres/PostgresReservedEmailRepository.scala
+++ b/app/models/database/postgres/PostgresReservedEmailRepository.scala
@@ -23,6 +23,6 @@ class PostgresReservedEmailRepository @Inject()(val metricsActorProvider: Metric
       """.stripMargin
     readOnly { implicit session =>
       sql.map(_.int(1)).single().apply().getOrElse(0) > 0
-    }(logFailure(s"Failed to check if the email $email is reserved"))
+    }(logFailure(s"Failed to check if email is reserved"))
   }
 }

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -3,7 +3,7 @@ package services
 import actors.{EventPublishingActorProvider, MetricsActorProviderStub}
 import akka.actor.ActorSystem
 import models.client._
-import models.database.postgres.{PostgresDeletedUserRepository, PostgresReservedUsernameRepository, PostgresSubjectAccessRequestRepository, PostgresUserRepository}
+import models.database.postgres._
 import util.UserConverter._
 import org.mockito.Mockito
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Matchers, WordSpec}
@@ -32,6 +32,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
   val pgDeletedUserRepo = mock[PostgresDeletedUserRepository]
   val pgUserRepo = mock[PostgresUserRepository]
   val pgReservedUsernameRepo = mock[PostgresReservedUsernameRepository]
+  val pgReservedEmailRepo = mock [PostgresReservedEmailRepository]
   val postgresSubjectAccessRequestRepository = mock[PostgresSubjectAccessRequestRepository]
   val brazeCmtService = mock[BrazeCmtService]
   implicit val actorSystem = ActorSystem()
@@ -43,7 +44,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
   val service =
     spy(new UserService(identityApiClient,
       eventPublishingActorProvider, salesforceService, salesforceIntegration, madgexService, exactTargetService,
-      discussionService, pgDeletedUserRepo, pgReservedUsernameRepo, pgUserRepo, postgresSubjectAccessRequestRepository, MetricsActorProviderStub, brazeCmtService))
+      discussionService, pgDeletedUserRepo, pgReservedUsernameRepo, pgReservedEmailRepo, pgUserRepo, postgresSubjectAccessRequestRepository, MetricsActorProviderStub, brazeCmtService))
 
   before {
     Mockito.reset(identityApiClient, eventPublishingActorProvider, service, madgexService, pgDeletedUserRepo, pgReservedUsernameRepo, pgUserRepo)

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -32,7 +32,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
   val pgDeletedUserRepo = mock[PostgresDeletedUserRepository]
   val pgUserRepo = mock[PostgresUserRepository]
   val pgReservedUsernameRepo = mock[PostgresReservedUsernameRepository]
-  val pgReservedEmailRepo = mock [PostgresReservedEmailRepository]
+  val pgReservedEmailRepo = mock[PostgresReservedEmailRepository]
   val postgresSubjectAccessRequestRepository = mock[PostgresSubjectAccessRequestRepository]
   val brazeCmtService = mock[BrazeCmtService]
   implicit val actorSystem = ActorSystem()
@@ -47,7 +47,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       discussionService, pgDeletedUserRepo, pgReservedUsernameRepo, pgReservedEmailRepo, pgUserRepo, postgresSubjectAccessRequestRepository, MetricsActorProviderStub, brazeCmtService))
 
   before {
-    Mockito.reset(identityApiClient, eventPublishingActorProvider, service, madgexService, pgDeletedUserRepo, pgReservedUsernameRepo, pgUserRepo)
+    Mockito.reset(identityApiClient, eventPublishingActorProvider, service, madgexService, pgDeletedUserRepo, pgReservedUsernameRepo, pgReservedEmailRepo, pgUserRepo)
   }
 
   "isUsernameChanged" should {
@@ -126,11 +126,25 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
 
       when(pgUserRepo.update(user, userUpdateRequest)).thenReturn(Future.successful(\/-(updatedUser)))
       when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(\/-{}))
+      when(pgReservedEmailRepo.isReserved(userUpdateRequest.email)).thenReturn(Future.successful(\/-(false)))
 
       val result = service.update(user, userUpdateRequest)
 
       Await.result(result, 1.second) shouldEqual \/-(updatedUser)
       verify(identityApiClient).sendEmailValidation(user.id)
+    }
+
+    "not update when unable to access reserved emails" in {
+      val user = User("id", "email@theguardian.com")
+      val userUpdateRequest = UserUpdateRequest(email = "changedEmail@theguardian.com", username = Some("username"))
+
+      val updatedUser = user.copy(email = userUpdateRequest.email)
+
+      when(pgReservedEmailRepo.isReserved(userUpdateRequest.email)).thenReturn(Future.successful(\/-(true)))
+
+      val result = service.update(user, userUpdateRequest)
+
+      Await.result(result, 1.second) shouldEqual -\/(ApiError("Email is reserved"))
     }
 
     "update madgex when jobs user changed" in {
@@ -142,6 +156,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
 
       when(pgUserRepo.update(user, userUpdateRequest)).thenReturn(Future.successful(\/-(updatedUser)))
       when(identityApiClient.sendEmailValidation(user.id)).thenReturn(Future.successful(\/-{}))
+      when(pgReservedEmailRepo.isReserved(userUpdateRequest.email)).thenReturn(Future.successful(\/-(false)))
 
       val result = service.update(user, userUpdateRequest)
 
@@ -156,6 +171,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updatedUser = user.copy(email = userUpdateRequest.email)
 
       when(pgUserRepo.update(user, userUpdateRequest)).thenReturn(Future.successful(\/-(updatedUser)))
+      when(pgReservedEmailRepo.isReserved(userUpdateRequest.email)).thenReturn(Future.successful(\/-(false)))
 
       Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual \/-(updatedUser)
       verifyZeroInteractions(madgexService)
@@ -168,6 +184,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updatedUser = user.copy(email = userUpdateRequest.email)
 
       when(pgUserRepo.update(user, userUpdateRequest)).thenReturn(Future.successful(\/-(updatedUser)))
+      when(pgReservedEmailRepo.isReserved(userUpdateRequest.email)).thenReturn(Future.successful(\/-(false)))
 
       Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual \/-(updatedUser)
       verifyZeroInteractions(identityApiClient)
@@ -180,6 +197,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val updatedUser = user.copy(email = userUpdateRequest.email)
 
       when(pgUserRepo.update(user, userUpdateRequest)).thenReturn(Future.successful(\/-(updatedUser)))
+      when(pgReservedEmailRepo.isReserved(userUpdateRequest.email)).thenReturn(Future.successful(\/-(false)))
 
       val result = service.update(user, userUpdateRequest)
 
@@ -191,6 +209,8 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val user = User("id", "email@theguardian.com")
       val updateRequest = UserUpdateRequest(email = user.email, username = Some("123"))
 
+      when(pgReservedEmailRepo.isReserved(updateRequest.email)).thenReturn(Future.successful(\/-(false)))
+
       Await.result(service.update(user, updateRequest), 1.second) shouldEqual -\/(ApiError("Username is invalid"))
       verifyZeroInteractions(pgUserRepo)
     }
@@ -199,6 +219,8 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val user = User("id", "email@theguardian.com")
       val updateRequest = UserUpdateRequest(email = user.email, username = Some("123456789012345678901"))
 
+      when(pgReservedEmailRepo.isReserved(updateRequest.email)).thenReturn(Future.successful(\/-(false)))
+
       Await.result(service.update(user, updateRequest), 1.second) shouldEqual -\/(ApiError("Username is invalid"))
       verifyZeroInteractions(pgUserRepo)
     }
@@ -206,6 +228,8 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
     "return bad request api error if the username is contains non alpha-numeric chars" in {
       val user = User("id", "email@theguardian.com")
       val updateRequest = UserUpdateRequest(email = user.email, username = Some("abc123$"))
+
+      when(pgReservedEmailRepo.isReserved(updateRequest.email)).thenReturn(Future.successful(\/-(false)))
 
       Await.result(service.update(user, updateRequest), 1.second) shouldEqual -\/(ApiError("Username is invalid"))
       verifyZeroInteractions(pgUserRepo)
@@ -218,6 +242,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       
 
       when(pgUserRepo.update(user, userUpdateRequest)).thenReturn(Future.successful(-\/(ApiError("boom"))))
+      when(pgReservedEmailRepo.isReserved(userUpdateRequest.email)).thenReturn(Future.successful(\/-(false)))
 
       Await.result(service.update(user, userUpdateRequest), 1.second) shouldEqual -\/(ApiError("boom"))
       verify(identityApiClient, never()).sendEmailValidation(user.id)

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -134,7 +134,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       verify(identityApiClient).sendEmailValidation(user.id)
     }
 
-    "not update when unable to access reserved emails" in {
+    "not update when email address is reserved" in {
       val user = User("id", "email@theguardian.com")
       val userUpdateRequest = UserUpdateRequest(email = "changedEmail@theguardian.com", username = Some("username"))
 


### PR DESCRIPTION
The user admin tool doesn't currently check if email addresses are reserved when manually changed. Open to any comments regarding the way the ApiResponse[Boolean] (Future of an Either) is handled in UserService.