### PR TITLE
Add email invalidation to user update

### DIFF
--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -57,6 +57,7 @@ import scalaz.{-\/, EitherT, \/-}
               )
 
               if (userEmailChanged) {
+                postgresUsersReadRepository.updateEmailValidationStatus(existingUser, false)
                 identityApiClient.sendEmailValidation(existingUser.id)
                 exactTargetService.updateEmailAddress(existingUser.email, userUpdateRequest.email)
                 brazeCmtService.updateEmailAddress(existingUser.id, existingUser.email, userUpdateRequest.email)

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -138,8 +138,6 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
       val user = User("id", "email@theguardian.com")
       val userUpdateRequest = UserUpdateRequest(email = "changedEmail@theguardian.com", username = Some("username"))
 
-      val updatedUser = user.copy(email = userUpdateRequest.email)
-
       when(pgReservedEmailRepo.isReserved(userUpdateRequest.email)).thenReturn(Future.successful(\/-(true)))
 
       val result = service.update(user, userUpdateRequest)

--- a/test/services/UserServiceTest.scala
+++ b/test/services/UserServiceTest.scala
@@ -132,6 +132,7 @@ class UserServiceTest extends WordSpec with MockitoSugar with Matchers with Befo
 
       Await.result(result, 1.second) shouldEqual \/-(updatedUser)
       verify(identityApiClient).sendEmailValidation(user.id)
+      verify(pgUserRepo, times(1)).updateEmailValidationStatus(user, false)
     }
 
     "not update when email address is reserved" in {


### PR DESCRIPTION
When changing an email address on user admin, the user's email address will become invalid until they click through on the validation email. 