### PR TITLE
Braze hard bounce and spam list endpoints

### DIFF
--- a/app/controllers/UsersController.scala
+++ b/app/controllers/UsersController.scala
@@ -129,6 +129,20 @@ import java.nio.file.Files
     }
   }
 
+  def removeFromBounceList(id: String) = auth.async { _ =>
+    EitherT(identityApiClient.removeFromBounceList(id)).fold(
+      error => InternalServerError(error),
+      _ => NoContent
+    )
+  }
+
+  def removeFromSpamList(id: String) = auth.async { _ =>
+    EitherT(identityApiClient.removeFromSpamList(id)).fold(
+      error => InternalServerError(error),
+      _ => NoContent
+    )
+  }
+
   def findOrphanByEmail(email: String) = (auth andThen orphanUserAction(email)) { request =>
     Ok(request.user)
   }

--- a/app/controllers/UsersController.scala
+++ b/app/controllers/UsersController.scala
@@ -131,14 +131,20 @@ import java.nio.file.Files
 
   def removeFromBounceList(id: String) = auth.async { _ =>
     EitherT(identityApiClient.removeFromBounceList(id)).fold(
-      error => InternalServerError(error),
+      error => {
+        logger.error("Failed to remove user from hard bounce list", error.message)
+        InternalServerError(error)
+      },
       _ => NoContent
     )
   }
 
   def removeFromSpamList(id: String) = auth.async { _ =>
     EitherT(identityApiClient.removeFromSpamList(id)).fold(
-      error => InternalServerError(error),
+      error => {
+        logger.error("Failed to remove user from spam list", error.message)
+        InternalServerError(error)
+      },
       _ => NoContent
     )
   }

--- a/app/services/IdentityApiClient.scala
+++ b/app/services/IdentityApiClient.scala
@@ -113,4 +113,24 @@ class IdentityApiClient @Inject() (ws: WSClient)(implicit ec: ExecutionContext) 
     }
   }
 
+  def removeFromBounceList(userId: String): ApiResponse[Unit] = {
+    addAuthHeaders(ws.url(s"$baseUrl/useremails/$userId/bounce-list-remove")).post("").map { response =>
+      if (response.status == 200) {
+        \/-(())
+      } else {
+        -\/(ApiError("unexpected response from idapi", s"${response.status}, ${response.body}"))
+      }
+    }
+  }
+
+  def removeFromSpamList(userId: String): ApiResponse[Unit] = {
+    addAuthHeaders(ws.url(s"$baseUrl/useremails/$userId/spam-list-remove")).post("").map { response =>
+      if (response.status == 200) {
+        \/-(())
+      } else {
+        -\/(ApiError("unexpected response from idapi", s"${response.status}, ${response.body}"))
+      }
+    }
+  }
+
 }

--- a/app/services/IdentityApiClient.scala
+++ b/app/services/IdentityApiClient.scala
@@ -91,6 +91,7 @@ class IdentityApiClient @Inject() (ws: WSClient)(implicit ec: ExecutionContext) 
     }
   }
 
+  // TODO: it seems that not all these methods have a way of recovering from a failed Future
   def unsubscribeAll(userId: String): ApiResponse[Unit] = {
     addAuthHeaders(ws.url(s"$baseUrl/useremails/$userId/unsubscribe")).post("").map { response =>
       if (response.status == 200) {
@@ -120,6 +121,9 @@ class IdentityApiClient @Inject() (ws: WSClient)(implicit ec: ExecutionContext) 
       } else {
         -\/(ApiError("unexpected response from idapi", s"${response.status}, ${response.body}"))
       }
+    }.recover { case e =>
+        logger.error("Could not remove user from hard bounce list", e.getMessage)
+      -\/(ApiError("Could not remove user from hard bounce list", e.getMessage))
     }
   }
 
@@ -130,7 +134,9 @@ class IdentityApiClient @Inject() (ws: WSClient)(implicit ec: ExecutionContext) 
       } else {
         -\/(ApiError("unexpected response from idapi", s"${response.status}, ${response.body}"))
       }
+    }.recover { case e =>
+      logger.error("Could not remove user from spam list", e.getMessage)
+      -\/(ApiError("Could not remove user from spam list", e.getMessage))
     }
   }
-
 }

--- a/app/services/IdentityApiClient.scala
+++ b/app/services/IdentityApiClient.scala
@@ -122,7 +122,6 @@ class IdentityApiClient @Inject() (ws: WSClient)(implicit ec: ExecutionContext) 
         -\/(ApiError("unexpected response from idapi", s"${response.status}, ${response.body}"))
       }
     }.recover { case e =>
-        logger.error("Could not remove user from hard bounce list", e.getMessage)
       -\/(ApiError("Could not remove user from hard bounce list", e.getMessage))
     }
   }
@@ -135,7 +134,6 @@ class IdentityApiClient @Inject() (ws: WSClient)(implicit ec: ExecutionContext) 
         -\/(ApiError("unexpected response from idapi", s"${response.status}, ${response.body}"))
       }
     }.recover { case e =>
-      logger.error("Could not remove user from spam list", e.getMessage)
       -\/(ApiError("Could not remove user from spam list", e.getMessage))
     }
   }

--- a/conf/routes
+++ b/conf/routes
@@ -15,5 +15,7 @@ POST       /v1/user/:id/validate-email              @controllers.UsersController
 POST       /v1/user/:id/unreserve-email             @controllers.UsersController.unreserveEmail(id: String)
 POST       /v1/user/:id/block-email                 @controllers.UsersController.blockEmail(id: String)
 POST       /v1/user/:id/unsubscribe-email           @controllers.UsersController.unsubcribeFromAllEmailLists(id: String)
+POST       /v1/user/:id/cmt/bounce-list-remove      @controllers.UsersController.removeFromBounceList(id: String)
+POST       /v1/user/:id/cmt/spam-list-remove        @controllers.UsersController.removeFromSpamList(id: String)
 
 GET        /v1/orphan/:email                        @controllers.UsersController.findOrphanByEmail(email: String)

--- a/test/controllers/UsersControllerTest.scala
+++ b/test/controllers/UsersControllerTest.scala
@@ -275,6 +275,34 @@ class UsersControllerTest extends WordSpec with Matchers with MockitoSugar with 
     }
   }
 
+  "removeFromBounceList" should {
+    "return 204 when user is removed from the Braze bounce list" in {
+      when(identityApiClient.removeFromBounceList(testIdentityId)).thenReturn(Future.successful(\/-{}))
+      val result = controller.removeFromBounceList(testIdentityId)(FakeRequest())
+      status(result) shouldEqual NO_CONTENT
+    }
+
+    "return 500 when there is an unexpected response from idapi" in {
+      when(identityApiClient.removeFromBounceList(testIdentityId)).thenReturn(Future.successful(-\/(ApiError(""))))
+      val result = controller.removeFromBounceList(testIdentityId)(FakeRequest())
+      status(result) shouldEqual INTERNAL_SERVER_ERROR
+    }
+  }
+
+  "removeFromSpamList" should {
+    "return 204 when user is removed from the Braze bounce list" in {
+      when(identityApiClient.removeFromSpamList(testIdentityId)).thenReturn(Future.successful(\/-{}))
+      val result = controller.removeFromSpamList(testIdentityId)(FakeRequest())
+      status(result) shouldEqual NO_CONTENT
+    }
+
+    "return 500 when there is an unexpected response from idapi" in {
+      when(identityApiClient.removeFromSpamList(testIdentityId)).thenReturn(Future.successful(-\/(ApiError(""))))
+      val result = controller.removeFromSpamList(testIdentityId)(FakeRequest())
+      status(result) shouldEqual INTERNAL_SERVER_ERROR
+    }
+  }
+
   "validateEmail" should {
     "return 404 when user is not found" in {
       when(identityUserAction.apply(any[String])).thenReturn(createIdentityUserActionLeftMock())


### PR DESCRIPTION
This is the 2nd PR allowing for new buttons in the useradmin tool to remove user's email addresses from Braze's spam and hard bounce lists. 

See initial PR here https://github.com/guardian/identity-admin/pull/252
And PR for identity api calls to Braze here https://github.com/guardian/identity/pull/1533

This PR makes calls from Identity Admin API to Identity API, where the requests to Braze are made.